### PR TITLE
Further changes for robots

### DIFF
--- a/FluxHaus.xcodeproj/project.pbxproj
+++ b/FluxHaus.xcodeproj/project.pbxproj
@@ -97,6 +97,10 @@
 		63DBD75A2B954486006603D0 /* WeatherView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636B9B39258E57D400DE97BD /* WeatherView.swift */; };
 		63DBD75B2B954486006603D0 /* WeatherAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6369A138259984E400888E5D /* WeatherAlertView.swift */; };
 		63DBD75C2B954486006603D0 /* AppliancesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 632CBC7D25870CBB003E4988 /* AppliancesView.swift */; };
+		63EB92652BE7E63C00B73102 /* ApplianceDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63EB92642BE7E63C00B73102 /* ApplianceDetailView.swift */; };
+		63EB92662BE7E63C00B73102 /* ApplianceDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63EB92642BE7E63C00B73102 /* ApplianceDetailView.swift */; };
+		63EB92672BE7E63C00B73102 /* ApplianceDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63EB92642BE7E63C00B73102 /* ApplianceDetailView.swift */; };
+		63EB92682BE7E63C00B73102 /* ApplianceDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63EB92642BE7E63C00B73102 /* ApplianceDetailView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -168,6 +172,7 @@
 		63DBD7502B95433C006603D0 /* HomeKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = HomeKit.framework; path = Platforms/XROS.platform/Developer/SDKs/XROS1.0.sdk/System/Library/Frameworks/HomeKit.framework; sourceTree = DEVELOPER_DIR; };
 		63DBD7522B954343006603D0 /* HealthKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = HealthKit.framework; path = Platforms/XROS.platform/Developer/SDKs/XROS1.0.sdk/System/Library/Frameworks/HealthKit.framework; sourceTree = DEVELOPER_DIR; };
 		63DBD75D2B954931006603D0 /* VisionOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = VisionOS.entitlements; sourceTree = "<group>"; };
+		63EB92642BE7E63C00B73102 /* ApplianceDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplianceDetailView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -229,6 +234,7 @@
 		632CBC23258682C8003E4988 /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				63EB92642BE7E63C00B73102 /* ApplianceDetailView.swift */,
 				632CBC7D25870CBB003E4988 /* AppliancesView.swift */,
 				63610D2D2BB883DA0048B9FF /* ApplianceViewHelpers.swift */,
 				636B9B4F258E912A00DE97BD /* BackgroundView.swift */,
@@ -578,6 +584,7 @@
 				635BD6752B9E030E009CEEA9 /* ContentView.swift in Sources */,
 				63610D332BB8864F0048B9FF /* CarDetailView.swift in Sources */,
 				6399EA312B9D3671000C8CA4 /* Login.swift in Sources */,
+				63EB92652BE7E63C00B73102 /* ApplianceDetailView.swift in Sources */,
 				6369A139259984E400888E5D /* WeatherAlertView.swift in Sources */,
 				632CBC7E25870CBB003E4988 /* AppliancesView.swift in Sources */,
 				632CBC902587B4AD003E4988 /* HomeConnect.swift in Sources */,
@@ -612,6 +619,7 @@
 				63610D342BB8864F0048B9FF /* CarDetailView.swift in Sources */,
 				6399EA322B9D3671000C8CA4 /* Login.swift in Sources */,
 				635BD6712B9DFAE1009CEEA9 /* WhereWeAre.swift in Sources */,
+				63EB92662BE7E63C00B73102 /* ApplianceDetailView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -636,6 +644,7 @@
 				636A059B2B9E6EE800D42C0D /* Battery.swift in Sources */,
 				63DBD75B2B954486006603D0 /* WeatherAlertView.swift in Sources */,
 				63DBD75C2B954486006603D0 /* AppliancesView.swift in Sources */,
+				63EB92672BE7E63C00B73102 /* ApplianceDetailView.swift in Sources */,
 				633F094A2BBB8F8F0052C088 /* CarHelper.swift in Sources */,
 				63DBD7542B95447A006603D0 /* HomeConnect.swift in Sources */,
 				63DBD7552B95447A006603D0 /* FluxHausConsts.swift in Sources */,
@@ -656,6 +665,7 @@
 				6399EA2A2B9CA534000C8CA4 /* LoadingView.swift in Sources */,
 				63610D2C2BB86F230048B9FF /* Car.swift in Sources */,
 				637CE4C82BE71FC000258158 /* RobotDetailView.swift in Sources */,
+				63EB92682BE7E63C00B73102 /* ApplianceDetailView.swift in Sources */,
 				6399EA392B9D7901000C8CA4 /* QueryFlux.swift in Sources */,
 				633F094B2BBB8F8F0052C088 /* CarHelper.swift in Sources */,
 				636A059C2B9E6EE800D42C0D /* Battery.swift in Sources */,

--- a/Shared/ApplianceDetailView.swift
+++ b/Shared/ApplianceDetailView.swift
@@ -1,0 +1,49 @@
+//
+//  CarDetailView.swift
+//  FluxHaus
+//
+//  Created by David Jensenius on 2024-03-30.
+//
+
+import SwiftUI
+
+struct ApplianceDetailView: View {
+    @Environment(\.presentationMode) var presentationMode
+    var appliance: Appliance
+    @State private var buttonsDisabled: Bool = false
+
+    var body: some View {
+        VStack {
+            HStack {
+                if appliance.name == "MopBot" {
+                    Image(systemName: "humidifier.and.droplets")
+                } else {
+                    Image(systemName: "fan")
+                }
+                Text(appliance.name)
+            }
+                .font(.title)
+                .padding([.top, .bottom])
+
+            VStack(alignment: .leading) {
+                if appliance.timeRunning != 0 {
+                    Text("Running for \(appliance.timeRunning) minutes")
+                }
+                if appliance.inUse == false {
+                    Text("Off")
+                } else {
+                    Text("Finishing in \(appliance.timeRemaining) minutes at \(appliance.timeFinish)")
+                    Text("Program: \(appliance.programName)")
+                    Text("Step: \(appliance.step)")
+                }
+            }.padding(.bottom)
+
+            Spacer()
+            Button(action: {
+                self.presentationMode.wrappedValue.dismiss()
+            }, label: {
+                Text("Dismiss")
+            }).padding()
+        }
+    }
+}

--- a/Shared/AppliancesView.swift
+++ b/Shared/AppliancesView.swift
@@ -28,6 +28,7 @@ struct Appliances: View {
     @State private var showCarModal: Bool = false
     @State private var showBroomBotModal: Bool = false
     @State private var showMopBotModal: Bool = false
+    @State private var showApplianceModal: [String: Bool] = [:]
 
     private let gridItemLayout = [GridItem(.flexible())]
 
@@ -62,15 +63,15 @@ struct Appliances: View {
                                                         index: theAppliances[app].index
                                                     )
                                                 )
-                                                    .font(.title2)
-                                                    .padding(.leading)
+                                                .font(.title2)
+                                                .padding(.leading)
                                                 Text(
                                                     getApplianceName(
                                                         type: theAppliances[app].name,
                                                         index: theAppliances[app].index
                                                     )
                                                 )
-                                                    .font(.title2)
+                                                .font(.title2)
                                                 Spacer()
                                             }
                                             Text(
@@ -79,9 +80,9 @@ struct Appliances: View {
                                                     index: theAppliances[app].index
                                                 )
                                             )
-                                                .font(.caption)
-                                                .foregroundStyle(.secondary)
-                                                .padding(.leading)
+                                            .font(.caption)
+                                            .foregroundStyle(.secondary)
+                                            .padding(.leading)
                                         }
                                         Text(
                                             getTimeRemaining(
@@ -89,11 +90,20 @@ struct Appliances: View {
                                                 index: theAppliances[app].index
                                             )
                                         )
-                                            .font(.title)
-                                            .padding()
+                                        .font(.title)
+                                        .padding()
                                     }
                                     .background(.regularMaterial, in: .rect(cornerRadius: 12))
                                     .hoverEffect()
+                                    .sheet(
+                                        isPresented:
+                                            binding(for: "\(theAppliances[app].name)-\(theAppliances[app].index)")
+                                    ) {
+                                        getSheet(
+                                            type: theAppliances[app].name,
+                                            index: theAppliances[app].index
+                                        )
+                                    }
                                 }.onTapGesture {
                                     if theAppliances[app].name == "Car" {
                                         self.car.fetchCarDetails()
@@ -102,6 +112,10 @@ struct Appliances: View {
                                         self.showMopBotModal = true
                                     } else if theAppliances[app].name == "BroomBot" {
                                         self.showBroomBotModal = true
+                                    } else {
+                                        self.showApplianceModal[
+                                            "\(theAppliances[app].name)-\(theAppliances[app].index)"
+                                        ] = true
                                     }
                                 }
                             }
@@ -119,6 +133,23 @@ struct Appliances: View {
         .sheet(isPresented: self.$showMopBotModal) {
             RobotDetailView(robot: robots.mopBot, robots: robots)
         }
+    }
+
+    private func binding(for key: String) -> Binding<Bool> {
+            return Binding(get: {
+                return self.showApplianceModal[key] ?? false
+            }, set: {
+                self.showApplianceModal[key] = $0
+            })
+        }
+
+    func getSheet(type: String, index: Int) -> ApplianceDetailView? {
+        if type == "Miele" {
+            return ApplianceDetailView(appliance: miele.appliances[index])
+        } else if type == "HomeConnect" {
+            return ApplianceDetailView(appliance: hconn.appliances[index])
+        }
+        return nil
     }
 
     func getIcon(type: String, index: Int) -> Image {

--- a/Shared/CarDetailView.swift
+++ b/Shared/CarDetailView.swift
@@ -14,9 +14,13 @@ struct CarDetailView: View {
 
     var body: some View {
         VStack {
-            Text("Car")
+            HStack {
+                Image(systemName: "car")
+                Text("Car")
+            }
                 .font(.title)
                 .padding([.top, .bottom])
+
             VStack(alignment: .leading) {
                 Text("EV Data Updated \(getCarTime(strDate: car.vehicle.evStatusTimestamp))")
                 Text("Battery: \(car.vehicle.batteryLevel)%, \(car.vehicle.distance) km")

--- a/Shared/RobotDetailView.swift
+++ b/Shared/RobotDetailView.swift
@@ -15,11 +15,18 @@ struct RobotDetailView: View {
 
     var body: some View {
         VStack {
-            Text(robot.name!)
+            HStack {
+                if robot.name! == "MopBot" {
+                    Image(systemName: "humidifier.and.droplets")
+                } else {
+                    Image(systemName: "fan")
+                }
+                Text(robot.name!)
+            }
                 .font(.title)
                 .padding([.top, .bottom])
+
             VStack(alignment: .leading) {
-                Text("Data Updated \(getCarTime(strDate: robot.timestamp))")
                 Text("Battery: \(robot.batteryLevel ?? 0)%")
                 if robot.charging == true && robot.batteryLevel ?? 0 < 100 {
                     Text("Charging")
@@ -32,6 +39,7 @@ struct RobotDetailView: View {
                 } else {
                     Text("Idle")
                 }
+                Text("Data Updated \(getCarTime(strDate: robot.timestamp))")
             }.padding(.bottom)
 
             VStack {
@@ -41,8 +49,10 @@ struct RobotDetailView: View {
                 } else {
                     Button("Start Cleaning", action: { performAction(action: "start") })
                         .disabled(self.buttonsDisabled).padding(.bottom)
-                    Button("Deep Clean (BroomBot + MopBot)", action: { performAction(action: "deepClean") })
-                        .disabled(self.buttonsDisabled)
+                    if robots.broomBot.running != true && robots.mopBot.running != true {
+                        Button("Deep Clean (BroomBot + MopBot)", action: { performAction(action: "deepClean") })
+                            .disabled(self.buttonsDisabled)
+                    }
                 }
             }.padding()
 


### PR DESCRIPTION
Addition of new feature:

* [`Shared/ApplianceDetailView.swift`](diffhunk://#diff-f67d24f6d65c2ce30eca065141b4e6117abcf835e115074f0431ab4f0bbfb686R1-R49): Added a new SwiftUI view `ApplianceDetailView` that displays detailed information about an appliance. The view includes the appliance's name, running time, program, and step. It also includes a dismiss button to close the view.

Modifications to accommodate new feature:

* [`FluxHaus.xcodeproj/project.pbxproj`](diffhunk://#diff-fc8c97ba9f6b7ee1de25ae7d7feeace05b2b7c8e9aac1b19502a59182a6c004eR100-R103): Added references to the new `ApplianceDetailView.swift` file in various sections of the Xcode project file. [[1]](diffhunk://#diff-fc8c97ba9f6b7ee1de25ae7d7feeace05b2b7c8e9aac1b19502a59182a6c004eR100-R103) [[2]](diffhunk://#diff-fc8c97ba9f6b7ee1de25ae7d7feeace05b2b7c8e9aac1b19502a59182a6c004eR175) [[3]](diffhunk://#diff-fc8c97ba9f6b7ee1de25ae7d7feeace05b2b7c8e9aac1b19502a59182a6c004eR237) [[4]](diffhunk://#diff-fc8c97ba9f6b7ee1de25ae7d7feeace05b2b7c8e9aac1b19502a59182a6c004eR587) [[5]](diffhunk://#diff-fc8c97ba9f6b7ee1de25ae7d7feeace05b2b7c8e9aac1b19502a59182a6c004eR622) [[6]](diffhunk://#diff-fc8c97ba9f6b7ee1de25ae7d7feeace05b2b7c8e9aac1b19502a59182a6c004eR647) [[7]](diffhunk://#diff-fc8c97ba9f6b7ee1de25ae7d7feeace05b2b7c8e9aac1b19502a59182a6c004eR668)
* [`Shared/AppliancesView.swift`](diffhunk://#diff-34157846dd161f22829d838c6ae8430c557492e0023ab6f94c9fca68b7f3cd91R31): Added a dictionary `showApplianceModal` to track which appliance detail views are currently being presented. Added a `sheet` modifier to each appliance in the grid to present the corresponding `ApplianceDetailView` when the appliance is tapped. Also added a `binding(for:)` function to create a binding for the `isPresented` parameter of the `sheet` modifier, and a `getSheet(type:index:)` function to return the correct `ApplianceDetailView` based on the appliance type and index. [[1]](diffhunk://#diff-34157846dd161f22829d838c6ae8430c557492e0023ab6f94c9fca68b7f3cd91R31) [[2]](diffhunk://#diff-34157846dd161f22829d838c6ae8430c557492e0023ab6f94c9fca68b7f3cd91R98-R106) [[3]](diffhunk://#diff-34157846dd161f22829d838c6ae8430c557492e0023ab6f94c9fca68b7f3cd91R115-R118) [[4]](diffhunk://#diff-34157846dd161f22829d838c6ae8430c557492e0023ab6f94c9fca68b7f3cd91R138-R154)

Minor adjustments for consistency:

* [`Shared/CarDetailView.swift`](diffhunk://#diff-e7e501136d5f41d449d2920488e61127afcdd5ea8771a264716facd4b5dd20f3R17-R23): Added an image to the title HStack for consistency with the new `ApplianceDetailView`.
* [`Shared/RobotDetailView.swift`](diffhunk://#diff-5b2a00cf40a74c8a4c066c1fd8cf17e5e11976453166203c00c5d06f09e34d88R18-L22): Moved the "Data Updated" text to a more consistent location in the VStack, and added an image to the title HStack. Also modified the conditions for displaying the "Deep Clean" button to ensure it is only displayed when both the BroomBot and MopBot are not running. [[1]](diffhunk://#diff-5b2a00cf40a74c8a4c066c1fd8cf17e5e11976453166203c00c5d06f09e34d88R18-L22) [[2]](diffhunk://#diff-5b2a00cf40a74c8a4c066c1fd8cf17e5e11976453166203c00c5d06f09e34d88R42) [[3]](diffhunk://#diff-5b2a00cf40a74c8a4c066c1fd8cf17e5e11976453166203c00c5d06f09e34d88R52-R56)