### PR TITLE
Fix wind speed and add some concurrency warning suppressions

### DIFF
--- a/Shared/Weather.swift
+++ b/Shared/Weather.swift
@@ -8,7 +8,7 @@
 import Foundation
 import CoreLocation
 import Combine
-import WeatherKit
+@preconcurrency import WeatherKit
 
 enum TimeType {
     case minute
@@ -27,7 +27,7 @@ struct ForecastInfo {
 }
 
 // MARK: - Location services
-class LocationManager: NSObject, ObservableObject, CLLocationManagerDelegate {
+@preconcurrency class LocationManager: NSObject, ObservableObject, CLLocationManagerDelegate {
     private let locationManager = CLLocationManager()
 
     private var status: CLAuthorizationStatus?

--- a/Shared/WeatherView.swift
+++ b/Shared/WeatherView.swift
@@ -28,7 +28,7 @@ struct WeatherView: View {
                     .font(.subheadline)
                 if (lman.weather) != nil {
                     Image(systemName: "wind")
-                    Text((lman.weather!.currentWeather.wind.speed.description))
+                    Text(getWind())
                         .font(.subheadline)
                         .padding(.trailing)
                 }
@@ -114,6 +114,17 @@ struct WeatherView: View {
             .formatted(.measurement(usage: .asProvided, numberFormatStyle: .number.precision(.fractionLength(0))))
         let weatherDescription = currentWeather.condition.description
         return "\(currentTemp), \(weatherDescription)"
+    }
+
+    func getWind() -> String {
+        if lman.weather == nil {
+            return "Loading"
+        }
+        let currentWeather = lman.weather!.currentWeather
+        let windSpeed = currentWeather.wind.speed
+        let speedText = windSpeed
+            .formatted()
+        return speedText.description
     }
 
     func getFeels() -> String {
@@ -202,11 +213,5 @@ struct WeatherView: View {
             theWhen = "starting in \(getTime(time: forecast.startingNumber!, type: forecast.startingType!))"
         }
         return "\(percent) chance of \(type) \(theWhen)"
-    }
-}
-
-struct Weather_Previews: PreviewProvider {
-    static var previews: some View {
-        WeatherView()
     }
 }

--- a/Shared/WhereWeAre.swift
+++ b/Shared/WhereWeAre.swift
@@ -55,9 +55,7 @@ struct WhereWeAre {
             // Extract result
             if let existingItem = item as? [String: Any],
                let passwordData = existingItem[kSecValueData as String] as? Data,
-               // swiftlint:disable non_optional_string_data_conversion
                let password = String(data: passwordData, encoding: .utf8) {
-                // swiftlint:enable non_optional_string_data_conversion
                 return password
             }
         }


### PR DESCRIPTION
This pull request includes several updates to improve the concurrency handling and refactor the wind speed display in the weather application. The most important changes include adding `@preconcurrency` annotations, refactoring the wind speed display logic, and removing unused preview providers.
Concurrency improvements:

* [`Shared/Weather.swift`](diffhunk://#diff-3cb2cb9762be1249a3ff6b2172a635f826e35865599a7ef4f512de825db5ac04L11-R11): Added `@preconcurrency` to the `WeatherKit` import to ensure proper concurrency handling.
* [`Shared/Weather.swift`](diffhunk://#diff-3cb2cb9762be1249a3ff6b2172a635f826e35865599a7ef4f512de825db5ac04L30-R30): Added `@preconcurrency` to the `LocationManager` class declaration to improve concurrency handling.

Code simplification:

* [`Shared/WeatherView.swift`](diffhunk://#diff-b1364248c4f8bd069bf2c5b37f2189effb6a3e7617a765ce3758562456525796R119-R129): Created a new `getWind` method to encapsulate the logic for retrieving wind speed, replacing inline code.
* [`Shared/WeatherView.swift`](diffhunk://#diff-b1364248c4f8bd069bf2c5b37f2189effb6a3e7617a765ce3758562456525796L207-L212): Removed the unnecessary `Weather_Previews` struct to clean up the code.

Code cleanup:

* [`Shared/WhereWeAre.swift`](diffhunk://#diff-19e33aa85f0bd9c65232b87538d34bc8f7322d4cf700d7e7e7333c817b7ac50fL58-L60): Removed unnecessary SwiftLint comments to clean up the code.