### PR TITLE
Refine macOS quick chat and resident mode

### DIFF
--- a/Shared/SystemNotifications.swift
+++ b/Shared/SystemNotifications.swift
@@ -15,4 +15,6 @@ extension Notification.Name {
     static let quickChatRequested: Notification.Name = Notification.Name("quickChatRequested")
     static let quickChatShortcutChanged: Notification.Name = Notification.Name("quickChatShortcutChanged")
     static let fullQuitRequested: Notification.Name = Notification.Name("fullQuitRequested")
+    static let openMainAppRequested: Notification.Name = Notification.Name("openMainAppRequested")
+    static let menuBarPreferenceChanged: Notification.Name = Notification.Name("menuBarPreferenceChanged")
 }

--- a/Tests macOS/Tests_macOS_ViewTests.swift
+++ b/Tests macOS/Tests_macOS_ViewTests.swift
@@ -5,9 +5,12 @@
 //  Created by Copilot on 2026-03-02.
 //
 
+// swiftlint:disable file_length
+
 import Testing
 import AppKit
 import SwiftUI
+import Carbon
 
 /// Drains pending DispatchQueue.main.async blocks so data population completes.
 @MainActor
@@ -96,6 +99,14 @@ struct MacOSViewSmokeTests {
     @Test("Quick Chat view renders without crashing")
     @MainActor func testQuickChatView() {
         let view = ChatView(chat: Chat(), style: .quick)
+        let controller = NSHostingController(rootView: view)
+        controller.loadView()
+        #expect(controller.view.frame.width >= 0)
+    }
+
+    @Test("Expanded Quick Chat view renders without crashing")
+    @MainActor func testExpandedQuickChatView() {
+        let view = ChatView(chat: Chat(), style: .quick, initialQuickChatExpanded: true)
         let controller = NSHostingController(rootView: view)
         controller.loadView()
         #expect(controller.view.frame.width >= 0)
@@ -208,17 +219,41 @@ struct QuickChatShortcutTests {
 
     @Test("Quick chat shortcut titles are stable")
     func testShortcutTitles() {
-        #expect(QuickChatShortcut.defaultShortcut == .optionSpace)
-        #expect(QuickChatShortcut.optionSpace.title == "Option+Space")
-        #expect(QuickChatShortcut.shiftCommandSpace.title == "Shift+Command+Space")
-        #expect(QuickChatShortcut.controlSpace.title == "Control+Space")
-        #expect(QuickChatShortcut.optionCommandSpace.title == "Option+Command+Space")
+        #expect(QuickChatShortcut.defaultShortcut.title == "⌥␣")
         #expect(QuickChatShortcut.disabled.title == "Disabled")
+    }
+
+    @Test("Quick chat shortcut migrates old preset values")
+    func testShortcutMigration() {
+        #expect(QuickChatShortcut.fromStored("shiftCommandSpace").title == "⇧⌘␣")
+        #expect(QuickChatShortcut.fromStored("controlSpace").title == "⌃␣")
+        #expect(QuickChatShortcut.fromStored("optionCommandSpace").title == "⌥⌘␣")
     }
 
     @Test("Quick chat shortcut fallback uses default")
     func testShortcutFallback() {
-        #expect(QuickChatShortcut.fromStored("invalid-shortcut") == .optionSpace)
+        #expect(QuickChatShortcut.fromStored("invalid-shortcut").title == "⌥␣")
+    }
+
+    @Test("Quick chat shortcut round-trips custom values")
+    func testShortcutRoundTrip() {
+        let shortcut = QuickChatShortcut(
+            keyCode: UInt32(kVK_ANSI_K),
+            carbonModifiers: UInt32(cmdKey | optionKey),
+            displayKey: "K"
+        )
+        #expect(QuickChatShortcut.fromStored(shortcut.rawValue) == shortcut)
+        #expect(shortcut.title == "⌥⌘K")
+    }
+
+    @Test("Quick chat shortcut preserves unshifted number row labels")
+    func testShortcutUnshiftedNumberRowLabel() {
+        let shortcut = QuickChatShortcut(
+            keyCode: UInt32(kVK_ANSI_9),
+            carbonModifiers: UInt32(shiftKey | cmdKey),
+            displayKey: "9"
+        )
+        #expect(shortcut.title == "⇧⌘9")
     }
 }
 

--- a/macOS/ChatView.swift
+++ b/macOS/ChatView.swift
@@ -17,6 +17,7 @@ enum ChatViewStyle {
 struct ChatView: View {
     @Bindable var chat: Chat
     var style: ChatViewStyle = .full
+    private let initialQuickChatExpanded: Bool
     @State private var inputText = ""
     @FocusState private var isInputFocused: Bool
     @State private var holdRecordStart: Date?
@@ -32,6 +33,14 @@ struct ChatView: View {
     // the NSTextView-backed multi-line TextField) to re-render on every token,
     // which triggers _NSDetectedLayoutRecursion on macOS.
     @State private var showSuggestions = false
+    @State private var quickChatExpanded = false
+
+    init(chat: Chat, style: ChatViewStyle = .full, initialQuickChatExpanded: Bool = false) {
+        self.chat = chat
+        self.style = style
+        self.initialQuickChatExpanded = initialQuickChatExpanded
+        _quickChatExpanded = State(initialValue: initialQuickChatExpanded)
+    }
 
     private func updateShowSuggestions() {
         guard let convId = chat.conversationId else { showSuggestions = false; return }
@@ -88,10 +97,24 @@ struct ChatView: View {
         VStack(spacing: 0) {
             quickChatHeader
             Divider()
-            chatDetail
+            if quickChatExpanded {
+                HStack(spacing: 0) {
+                    chatSidebar
+                        .frame(width: 260)
+                    Divider()
+                    chatDetail
+                }
+            } else {
+                chatDetail
+            }
         }
-        .frame(minWidth: 560, minHeight: 420)
+        .frame(
+            minWidth: quickChatExpanded ? 820 : 560,
+            idealWidth: quickChatExpanded ? 960 : 720,
+            minHeight: 420
+        )
         .background(Theme.Colors.background)
+        .animation(.easeInOut(duration: 0.2), value: quickChatExpanded)
     }
 
     private var quickChatHeader: some View {
@@ -105,6 +128,15 @@ struct ChatView: View {
                     .lineLimit(1)
             }
             Spacer()
+            Button(action: {
+                quickChatExpanded.toggle()
+            }, label: {
+                Label(
+                    quickChatExpanded ? "Hide History" : "Show History",
+                    systemImage: "sidebar.left"
+                )
+            })
+            .buttonStyle(.borderless)
             Button(action: {
                 Task { await chat.createNewConversation() }
             }, label: {
@@ -502,9 +534,8 @@ extension ChatView {
     }
 
     private func openAssistantInMainApp() {
-        NSApp.activate(ignoringOtherApps: true)
         NotificationCenter.default.post(
-            name: Notification.Name("navigateToSection"),
+            name: .openMainAppRequested,
             object: nil,
             userInfo: ["section": SidebarItem.assistant.rawValue]
         )

--- a/macOS/MacApp.swift
+++ b/macOS/MacApp.swift
@@ -5,6 +5,8 @@
 //  Created by Copilot on 2026-03-02.
 //
 
+// swiftlint:disable file_length
+
 import SwiftUI
 import AppKit
 import Carbon
@@ -111,14 +113,19 @@ final class QuickChatWindowController: NSWindowController {
     init(chat: Chat) {
         let rootView = ChatView(chat: chat, style: .quick)
         let hostingController = NSHostingController(rootView: rootView)
-        let window = NSWindow(contentViewController: hostingController)
+        let window = NSPanel(
+            contentViewController: hostingController
+        )
         window.title = "Quick Chat"
         window.setContentSize(NSSize(width: 720, height: 560))
         window.minSize = NSSize(width: 560, height: 420)
         window.titlebarAppearsTransparent = true
         window.toolbarStyle = .unifiedCompact
         window.isReleasedWhenClosed = false
-        window.collectionBehavior = [.moveToActiveSpace]
+        window.isFloatingPanel = true
+        window.hidesOnDeactivate = false
+        window.collectionBehavior = [.moveToActiveSpace, .fullScreenAuxiliary]
+        window.identifier = NSUserInterfaceItemIdentifier("QuickChatWindow")
         super.init(window: window)
         shouldCascadeWindows = false
     }
@@ -129,9 +136,10 @@ final class QuickChatWindowController: NSWindowController {
     }
 
     func present() {
-        NSApp.activate(ignoringOtherApps: true)
         showWindow(nil)
         window?.center()
+        window?.orderFrontRegardless()
+        NSApp.activate(ignoringOtherApps: true)
         window?.makeKeyAndOrderFront(nil)
     }
 }
@@ -174,10 +182,22 @@ final class MacAppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
         guard shouldFullyTerminate || !isMenuBarResident else {
-            sender.hide(nil)
+            dismissMainInterface()
             return .terminateCancel
         }
         return .terminateNow
+    }
+
+    func applicationShouldHandleReopen(
+        _ sender: NSApplication,
+        hasVisibleWindows flag: Bool
+    ) -> Bool {
+        presentMainApp()
+        return true
+    }
+
+    func requestFullQuit() {
+        performFullQuit()
     }
 
     private var isMenuBarResident: Bool {
@@ -213,6 +233,25 @@ final class MacAppDelegate: NSObject, NSApplicationDelegate {
                 Task { @MainActor [weak self] in
                     self?.performFullQuit()
                 }
+            },
+            center.addObserver(
+                forName: .openMainAppRequested,
+                object: nil,
+                queue: .main
+            ) { [weak self] notification in
+                let section = notification.userInfo?["section"] as? String
+                Task { @MainActor [weak self] in
+                    self?.presentMainApp(section: section)
+                }
+            },
+            center.addObserver(
+                forName: .menuBarPreferenceChanged,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                Task { @MainActor [weak self] in
+                    self?.handleMenuBarPreferenceChanged()
+                }
             }
         ]
     }
@@ -230,6 +269,56 @@ final class MacAppDelegate: NSObject, NSApplicationDelegate {
             quickChatWindowController = QuickChatWindowController(chat: sharedChat)
         }
         quickChatWindowController?.present()
+    }
+
+    private func presentMainApp(section: String? = nil) {
+        restoreDockPresence()
+        restorePrimaryWindows()
+        NSApp.activate(ignoringOtherApps: true)
+        if let section {
+            NotificationCenter.default.post(
+                name: Notification.Name("navigateToSection"),
+                object: nil,
+                userInfo: ["section": section]
+            )
+        }
+    }
+
+    private func handleMenuBarPreferenceChanged() {
+        restoreDockPresence()
+    }
+
+    private func enterResidentMode() {
+        guard isMenuBarResident else { return }
+        _ = NSApp.setActivationPolicy(.accessory)
+    }
+
+    private func restoreDockPresence() {
+        _ = NSApp.setActivationPolicy(.regular)
+    }
+
+    private func dismissMainInterface() {
+        enterResidentMode()
+        primaryWindows.forEach { window in
+            window.orderOut(nil)
+        }
+        NSApp.deactivate()
+    }
+
+    private func restorePrimaryWindows() {
+        if primaryWindows.isEmpty {
+            NSApp.unhide(nil)
+            return
+        }
+        primaryWindows.forEach { window in
+            window.makeKeyAndOrderFront(nil)
+        }
+    }
+
+    private var primaryWindows: [NSWindow] {
+        NSApp.windows.filter { window in
+            window.identifier?.rawValue != "QuickChatWindow"
+        }
     }
 
     private func performFullQuit() {
@@ -306,6 +395,14 @@ struct MacApp: App {
                     queryFlux(password: WhereWeAre.getPassword() ?? "")
                 }
                 .keyboardShortcut("r", modifiers: .command)
+            }
+
+            CommandGroup(after: .appTermination) {
+                Divider()
+                Button("Quit FluxHaus Completely") {
+                    appDelegate.requestFullQuit()
+                }
+                .keyboardShortcut("q", modifiers: [.command, .option])
             }
         }
 

--- a/macOS/MenuBarView.swift
+++ b/macOS/MenuBarView.swift
@@ -218,7 +218,7 @@ struct MenuBarView: View {
         HStack {
             Button("Open FluxHaus") {
                 dismiss()
-                NSApp.activate(ignoringOtherApps: true)
+                NotificationCenter.default.post(name: .openMainAppRequested, object: nil)
             }
             .font(Theme.Fonts.caption)
             Spacer()
@@ -231,12 +231,6 @@ struct MenuBarView: View {
                 })
                 .font(Theme.Fonts.caption)
             }
-            Spacer()
-            Button("Quit Fully") {
-                dismiss()
-                NotificationCenter.default.post(name: .fullQuitRequested, object: nil)
-            }
-            .font(Theme.Fonts.caption)
         }
     }
 
@@ -274,9 +268,8 @@ struct MenuBarView: View {
     }
 
     private func openAppToSection(_ section: SidebarItem) {
-        NSApp.activate(ignoringOtherApps: true)
         NotificationCenter.default.post(
-            name: Notification.Name("navigateToSection"),
+            name: .openMainAppRequested,
             object: nil,
             userInfo: ["section": section.rawValue]
         )

--- a/macOS/SettingsView.swift
+++ b/macOS/SettingsView.swift
@@ -6,56 +6,327 @@
 //
 
 import SwiftUI
+import AppKit
 import Carbon
 
-enum QuickChatShortcut: String, CaseIterable, Identifiable {
-    case optionSpace
-    case shiftCommandSpace
-    case controlSpace
-    case optionCommandSpace
-    case disabled
+struct QuickChatShortcut: Equatable {
+    private struct Payload: Codable {
+        let keyCode: UInt32?
+        let carbonModifiers: UInt32?
+        let displayKey: String?
+    }
 
-    static let defaultShortcut: QuickChatShortcut = .optionSpace
+    let keyCode: UInt32?
+    let carbonModifiers: UInt32?
+    let displayKey: String?
 
-    var id: String { rawValue }
+    static let defaultShortcut = QuickChatShortcut(
+        keyCode: UInt32(kVK_Space),
+        carbonModifiers: UInt32(optionKey),
+        displayKey: "␣"
+    )
+
+    static let disabled = QuickChatShortcut(
+        keyCode: nil,
+        carbonModifiers: nil,
+        displayKey: nil
+    )
+
+    var rawValue: String {
+        guard !isDisabled else { return "disabled" }
+        let payload = Payload(
+            keyCode: keyCode,
+            carbonModifiers: carbonModifiers,
+            displayKey: displayKey
+        )
+        guard let data = try? JSONEncoder().encode(payload) else {
+            return "disabled"
+        }
+        return "custom:\(data.base64EncodedString())"
+    }
 
     var title: String {
-        switch self {
-        case .optionSpace:
-            "Option+Space"
-        case .shiftCommandSpace:
-            "Shift+Command+Space"
-        case .controlSpace:
-            "Control+Space"
-        case .optionCommandSpace:
-            "Option+Command+Space"
-        case .disabled:
-            "Disabled"
-        }
+        guard !isDisabled, let displayKey else { return "Disabled" }
+        return "\(Self.modifierSymbols(for: carbonModifiers ?? 0))\(displayKey)"
     }
 
-    var keyCode: UInt32? {
-        guard self != .disabled else { return nil }
-        return UInt32(kVK_Space)
-    }
-
-    var carbonModifiers: UInt32? {
-        switch self {
-        case .optionSpace:
-            UInt32(optionKey)
-        case .shiftCommandSpace:
-            UInt32(shiftKey | cmdKey)
-        case .controlSpace:
-            UInt32(controlKey)
-        case .optionCommandSpace:
-            UInt32(optionKey | cmdKey)
-        case .disabled:
-            nil
-        }
+    var isDisabled: Bool {
+        keyCode == nil || carbonModifiers == nil
     }
 
     static func fromStored(_ rawValue: String) -> QuickChatShortcut {
-        QuickChatShortcut(rawValue: rawValue) ?? .defaultShortcut
+        switch rawValue {
+        case "optionSpace":
+            return defaultShortcut
+        case "shiftCommandSpace":
+            return QuickChatShortcut(
+                keyCode: UInt32(kVK_Space),
+                carbonModifiers: UInt32(shiftKey | cmdKey),
+                displayKey: "␣"
+            )
+        case "controlSpace":
+            return QuickChatShortcut(
+                keyCode: UInt32(kVK_Space),
+                carbonModifiers: UInt32(controlKey),
+                displayKey: "␣"
+            )
+        case "optionCommandSpace":
+            return QuickChatShortcut(
+                keyCode: UInt32(kVK_Space),
+                carbonModifiers: UInt32(optionKey | cmdKey),
+                displayKey: "␣"
+            )
+        case "disabled":
+            return disabled
+        default:
+            guard rawValue.hasPrefix("custom:"),
+                  let data = Data(base64Encoded: String(rawValue.dropFirst(7))),
+                  let payload = try? JSONDecoder().decode(Payload.self, from: data) else {
+                return defaultShortcut
+            }
+            return QuickChatShortcut(
+                keyCode: payload.keyCode,
+                carbonModifiers: payload.carbonModifiers,
+                displayKey: payload.displayKey
+            )
+        }
+    }
+
+    static func fromEvent(_ event: NSEvent) -> QuickChatShortcut? {
+        let modifiers = carbonModifiers(from: event.modifierFlags)
+        guard modifiers != 0 else { return nil }
+        guard let displayKey = displayKey(for: event) else { return nil }
+        return QuickChatShortcut(
+            keyCode: UInt32(event.keyCode),
+            carbonModifiers: modifiers,
+            displayKey: displayKey
+        )
+    }
+
+    private static func carbonModifiers(from flags: NSEvent.ModifierFlags) -> UInt32 {
+        let deviceIndependentFlags = flags.intersection(.deviceIndependentFlagsMask)
+        var result: UInt32 = 0
+        if deviceIndependentFlags.contains(.command) {
+            result |= UInt32(cmdKey)
+        }
+        if deviceIndependentFlags.contains(.option) {
+            result |= UInt32(optionKey)
+        }
+        if deviceIndependentFlags.contains(.control) {
+            result |= UInt32(controlKey)
+        }
+        if deviceIndependentFlags.contains(.shift) {
+            result |= UInt32(shiftKey)
+        }
+        return result
+    }
+
+    private static func modifierSymbols(for modifiers: UInt32) -> String {
+        var parts: [String] = []
+        if modifiers & UInt32(controlKey) != 0 {
+            parts.append("⌃")
+        }
+        if modifiers & UInt32(optionKey) != 0 {
+            parts.append("⌥")
+        }
+        if modifiers & UInt32(shiftKey) != 0 {
+            parts.append("⇧")
+        }
+        if modifiers & UInt32(cmdKey) != 0 {
+            parts.append("⌘")
+        }
+        return parts.joined()
+    }
+
+    private static func displayKey(for event: NSEvent) -> String? {
+        let specialKeys: [UInt16: String] = [
+            UInt16(kVK_Return): "↩",
+            UInt16(kVK_Tab): "⇥",
+            UInt16(kVK_Space): "␣",
+            UInt16(kVK_Delete): "⌫",
+            UInt16(kVK_Escape): "⎋",
+            UInt16(kVK_ForwardDelete): "⌦",
+            UInt16(kVK_LeftArrow): "←",
+            UInt16(kVK_RightArrow): "→",
+            UInt16(kVK_DownArrow): "↓",
+            UInt16(kVK_UpArrow): "↑",
+            UInt16(kVK_Home): "↖",
+            UInt16(kVK_End): "↘",
+            UInt16(kVK_PageUp): "⇞",
+            UInt16(kVK_PageDown): "⇟",
+            UInt16(kVK_Help): "Help",
+            UInt16(kVK_F1): "F1",
+            UInt16(kVK_F2): "F2",
+            UInt16(kVK_F3): "F3",
+            UInt16(kVK_F4): "F4",
+            UInt16(kVK_F5): "F5",
+            UInt16(kVK_F6): "F6",
+            UInt16(kVK_F7): "F7",
+            UInt16(kVK_F8): "F8",
+            UInt16(kVK_F9): "F9",
+            UInt16(kVK_F10): "F10",
+            UInt16(kVK_F11): "F11",
+            UInt16(kVK_F12): "F12",
+            UInt16(kVK_F13): "F13",
+            UInt16(kVK_F14): "F14",
+            UInt16(kVK_F15): "F15",
+            UInt16(kVK_F16): "F16",
+            UInt16(kVK_F17): "F17",
+            UInt16(kVK_F18): "F18",
+            UInt16(kVK_F19): "F19",
+            UInt16(kVK_F20): "F20"
+        ]
+        if let specialKey = specialKeys[event.keyCode] {
+            return specialKey
+        }
+        if let translatedCharacter = baseDisplayKey(for: event.keyCode) {
+            return translatedCharacter
+        }
+        guard let characters = event.charactersIgnoringModifiers?
+            .folding(options: .caseInsensitive, locale: .current)
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !characters.isEmpty else {
+            return nil
+        }
+        return characters.count == 1 ? characters.uppercased() : characters.capitalized
+    }
+
+    private static func baseDisplayKey(for keyCode: UInt16) -> String? {
+        guard let inputSource = TISCopyCurrentKeyboardLayoutInputSource()?.takeRetainedValue(),
+              let layoutDataPointer = TISGetInputSourceProperty(
+                  inputSource,
+                  kTISPropertyUnicodeKeyLayoutData
+              ) else {
+            return nil
+        }
+        let layoutData = unsafeBitCast(layoutDataPointer, to: CFData.self)
+        guard let keyboardLayoutData = CFDataGetBytePtr(layoutData) else {
+            return nil
+        }
+        let keyboardLayout = keyboardLayoutData.withMemoryRebound(
+            to: UCKeyboardLayout.self,
+            capacity: 1
+        ) { $0 }
+
+        var deadKeyState: UInt32 = 0
+        var length = 0
+        var characters = [UniChar](repeating: 0, count: 4)
+        let status = UCKeyTranslate(
+            keyboardLayout,
+            keyCode,
+            UInt16(kUCKeyActionDown),
+            0,
+            UInt32(LMGetKbdType()),
+            OptionBits(kUCKeyTranslateNoDeadKeysBit),
+            &deadKeyState,
+            characters.count,
+            &length,
+            &characters
+        )
+
+        guard status == noErr, length > 0 else {
+            return nil
+        }
+
+        let string = String(utf16CodeUnits: characters, count: Int(length))
+            .folding(options: .caseInsensitive, locale: .current)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !string.isEmpty else {
+            return nil
+        }
+        return string.count == 1 ? string.uppercased() : string.capitalized
+    }
+}
+
+struct ShortcutRecorderField: NSViewRepresentable {
+    @Binding var shortcutRawValue: String
+
+    func makeNSView(context: Context) -> ShortcutRecorderTextField {
+        let textField = ShortcutRecorderTextField()
+        textField.onShortcutChange = { shortcut in
+            shortcutRawValue = shortcut.rawValue
+        }
+        textField.update(shortcut: QuickChatShortcut.fromStored(shortcutRawValue))
+        return textField
+    }
+
+    func updateNSView(_ nsView: ShortcutRecorderTextField, context: Context) {
+        nsView.onShortcutChange = { shortcut in
+            shortcutRawValue = shortcut.rawValue
+        }
+        nsView.update(shortcut: QuickChatShortcut.fromStored(shortcutRawValue))
+    }
+}
+
+@MainActor
+final class ShortcutRecorderTextField: NSTextField {
+    var onShortcutChange: ((QuickChatShortcut) -> Void)?
+    private var currentShortcut = QuickChatShortcut.defaultShortcut
+    private var isRecording = false {
+        didSet {
+            updateAppearance()
+        }
+    }
+
+    override var acceptsFirstResponder: Bool { true }
+
+    init() {
+        super.init(frame: .zero)
+        isEditable = false
+        isSelectable = false
+        isBezeled = true
+        drawsBackground = true
+        backgroundColor = .controlBackgroundColor
+        focusRingType = .default
+        alignment = .center
+        font = NSFont.systemFont(ofSize: NSFont.systemFontSize)
+        lineBreakMode = .byTruncatingMiddle
+        updateAppearance()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        window?.makeFirstResponder(self)
+        isRecording = true
+        super.mouseDown(with: event)
+    }
+
+    override func keyDown(with event: NSEvent) {
+        guard isRecording else {
+            super.keyDown(with: event)
+            return
+        }
+        if event.keyCode == UInt16(kVK_Escape) {
+            isRecording = false
+            window?.makeFirstResponder(nil)
+            return
+        }
+        guard let shortcut = QuickChatShortcut.fromEvent(event) else {
+            NSSound.beep()
+            return
+        }
+        currentShortcut = shortcut
+        onShortcutChange?(shortcut)
+        isRecording = false
+        window?.makeFirstResponder(nil)
+    }
+
+    override func resignFirstResponder() -> Bool {
+        isRecording = false
+        return super.resignFirstResponder()
+    }
+
+    func update(shortcut: QuickChatShortcut) {
+        currentShortcut = shortcut
+        updateAppearance()
+    }
+
+    private func updateAppearance() {
+        stringValue = isRecording ? "Type shortcut" : currentShortcut.title
     }
 }
 
@@ -79,24 +350,44 @@ struct SettingsView: View {
 
     private var generalTab: some View {
         Form {
-            Toggle("Show in Menu Bar", isOn: $showMenuBar)
-            Picker("Quick Chat Shortcut", selection: $quickChatShortcutRawValue) {
-                ForEach(QuickChatShortcut.allCases) { shortcut in
-                    Text(shortcut.title).tag(shortcut.rawValue)
-                }
+            Section("Menu Bar") {
+                Toggle("Show in Menu Bar", isOn: $showMenuBar)
+                Text("Keep FluxHaus available from the menu bar when the main window is closed.")
+                    .font(Theme.Fonts.caption)
+                    .foregroundColor(Theme.Colors.textSecondary)
             }
-            Text(
-                "Use the quick chat shortcut to open a lightweight assistant window "
-                    + "while FluxHaus stays available in the menu bar."
-            )
-            .font(Theme.Fonts.caption)
-            .foregroundColor(Theme.Colors.textSecondary)
-            Button("Open Quick Chat") {
-                NotificationCenter.default.post(name: .quickChatRequested, object: nil)
+
+            Section("Quick Chat") {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Global Shortcut")
+                        .font(Theme.Fonts.bodySmall)
+                    ShortcutRecorderField(shortcutRawValue: $quickChatShortcutRawValue)
+                        .frame(width: 240, height: 28)
+                    HStack {
+                        Button("Reset to Default") {
+                            quickChatShortcutRawValue = QuickChatShortcut.defaultShortcut.rawValue
+                        }
+                        Button("Disable Shortcut") {
+                            quickChatShortcutRawValue = QuickChatShortcut.disabled.rawValue
+                        }
+                    }
+                }
+                Text(
+                    "Click the field, then press any modifier-based key combination to record "
+                        + "a global shortcut for Quick Chat. Shifted keys keep their unshifted symbol."
+                )
+                .font(Theme.Fonts.caption)
+                .foregroundColor(Theme.Colors.textSecondary)
+                Button("Open Quick Chat") {
+                    NotificationCenter.default.post(name: .quickChatRequested, object: nil)
+                }
             }
         }
         .formStyle(.grouped)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .onChange(of: showMenuBar) {
+            NotificationCenter.default.post(name: .menuBarPreferenceChanged, object: nil)
+        }
         .onChange(of: quickChatShortcutRawValue) {
             let normalized = QuickChatShortcut.fromStored(quickChatShortcutRawValue).rawValue
             if normalized != quickChatShortcutRawValue {


### PR DESCRIPTION
## Summary
- move the explicit full-quit action into the FluxHaus app menu and keep resident mode out of the Dock on standard quit
- make the macOS quick chat shortcut fully customizable with native shortcut symbols and unshifted key labels
- keep quick chat independent of the main window and let it expand inline to show conversation history

## Validation
- `swiftlint lint --strict --config .swiftlint.yml Shared/SystemNotifications.swift macOS/ChatView.swift macOS/MacApp.swift macOS/MenuBarView.swift macOS/SettingsView.swift 'Tests macOS/Tests_macOS_ViewTests.swift'`
- `xcodebuild test -project FluxHaus.xcodeproj -scheme 'FluxHaus (macOS)' -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=\x27\x27`