### PR TITLE
Add GT3 scooter integration

### DIFF
--- a/FluxHaus.xcodeproj/project.pbxproj
+++ b/FluxHaus.xcodeproj/project.pbxproj
@@ -100,6 +100,15 @@ MP0002000000000000000004 /* MarkdownParser.swift in Sources */ = {isa = PBXBuild
 		635F9D062BAF836C000700FD /* MieleAppliance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 635F9D052BAF836C000700FD /* MieleAppliance.swift */; };
 		635F9D082BAF836C000700FD /* MieleAppliance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 635F9D052BAF836C000700FD /* MieleAppliance.swift */; };
 		63610D292BB86F230048B9FF /* Car.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63610D282BB86F230048B9FF /* Car.swift */; };
+		BEA67E939CA04EFAA36CEACF /* Scooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF67D2F97BC4B6C8737FCC9 /* Scooter.swift */; };
+		42E9D45E3DEE4ED4BF3EBB9C /* ScooterDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8CB990FC6404C8682E3BE62 /* ScooterDetailView.swift */; };
+		BE52C047E38648D2BBCF9F89 /* Scooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF67D2F97BC4B6C8737FCC9 /* Scooter.swift */; };
+		3CFA1F5604BA445D83EE6D88 /* ScooterDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8CB990FC6404C8682E3BE62 /* ScooterDetailView.swift */; };
+		233E302E4A3E42AEA96D94E2 /* Scooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF67D2F97BC4B6C8737FCC9 /* Scooter.swift */; };
+		FC70519504B244809D095CEC /* ScooterDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8CB990FC6404C8682E3BE62 /* ScooterDetailView.swift */; };
+		F0779E97B0AB462F8FA3C9F4 /* Scooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF67D2F97BC4B6C8737FCC9 /* Scooter.swift */; };
+		A8FDEEF5BAC3453BB825E1DF /* ScooterDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8CB990FC6404C8682E3BE62 /* ScooterDetailView.swift */; };
+		4C4BF431831E40DDB81B5B12 /* Scooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF67D2F97BC4B6C8737FCC9 /* Scooter.swift */; };
 		63610D2B2BB86F230048B9FF /* Car.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63610D282BB86F230048B9FF /* Car.swift */; };
 		63610D2E2BB883DA0048B9FF /* ApplianceViewHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63610D2D2BB883DA0048B9FF /* ApplianceViewHelpers.swift */; };
 		63610D302BB883DA0048B9FF /* ApplianceViewHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63610D2D2BB883DA0048B9FF /* ApplianceViewHelpers.swift */; };
@@ -364,6 +373,8 @@ MP0001000000000000000001 /* MarkdownParser.swift */ = {isa = PBXFileReference; l
 		635BD6742B9E030E009CEEA9 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		635F9D052BAF836C000700FD /* MieleAppliance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MieleAppliance.swift; sourceTree = "<group>"; };
 		63610D282BB86F230048B9FF /* Car.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Car.swift; sourceTree = "<group>"; };
+		CEF67D2F97BC4B6C8737FCC9 /* Scooter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Scooter.swift; sourceTree = "<group>"; };
+		C8CB990FC6404C8682E3BE62 /* ScooterDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScooterDetailView.swift; sourceTree = "<group>"; };
 		63610D2D2BB883DA0048B9FF /* ApplianceViewHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplianceViewHelpers.swift; sourceTree = "<group>"; };
 		63610D322BB8864F0048B9FF /* CarDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarDetailView.swift; sourceTree = "<group>"; };
 		6368AE242EEBF2E600015B3C /* AppIntents.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppIntents.framework; path = System/Library/Frameworks/AppIntents.framework; sourceTree = SDKROOT; };
@@ -533,6 +544,8 @@ MP0001000000000000000001 /* MarkdownParser.swift */ = {isa = PBXFileReference; l
 				AA0001000000000000000002 /* Chat.swift */,
 				AA0001000000000000000001 /* ChatService.swift */,
 				63610D282BB86F230048B9FF /* Car.swift */,
+				CEF67D2F97BC4B6C8737FCC9 /* Scooter.swift */,
+				C8CB990FC6404C8682E3BE62 /* ScooterDetailView.swift */,
 				63610D322BB8864F0048B9FF /* CarDetailView.swift */,
 				633F09472BBB8F8F0052C088 /* CarHelper.swift */,
 				632CBC25258682C8003E4988 /* DateTimeView.swift */,
@@ -1013,6 +1026,8 @@ MP0001000000000000000001 /* MarkdownParser.swift */,
 				638F139E7CAD98A830B3DD77 /* Chat.swift in Sources */,
 				8716D5FE3271F7DBCEF8D744 /* ChatService.swift in Sources */,
 				92895C4DCFEB63889AE653C5 /* Car.swift in Sources */,
+				BEA67E939CA04EFAA36CEACF /* Scooter.swift in Sources */,
+				42E9D45E3DEE4ED4BF3EBB9C /* ScooterDetailView.swift in Sources */,
 				FD5BDD26916198636BEBC72A /* CarDetailView.swift in Sources */,
 				E222079D6E3C7E5941D2D5C0 /* CarHelper.swift in Sources */,
 				47DAD3A56DB24CE1A601DE56 /* DateTimeView.swift in Sources */,
@@ -1095,6 +1110,8 @@ MP0002000000000000000001 /* MarkdownParser.swift in Sources */,
 				AA0003000000000000000001 /* Chat.swift in Sources */,
 				AA0004000000000000000001 /* ChatView.swift in Sources */,
 				63610D292BB86F230048B9FF /* Car.swift in Sources */,
+				BE52C047E38648D2BBCF9F89 /* Scooter.swift in Sources */,
+				3CFA1F5604BA445D83EE6D88 /* ScooterDetailView.swift in Sources */,
 				63A159282C5E9763003F3796 /* LoginStucts.swift in Sources */,
 				0519DE362C5E9763003F3796 /* Theme.swift in Sources */,
 				632CBC4D258682C9003E4988 /* FluxHausApp.swift in Sources */,
@@ -1147,6 +1164,7 @@ MP0002000000000000000002 /* MarkdownParser.swift in Sources */,
 				636BF1F02C5D8EFB00C1244C /* SystemNotifications.swift in Sources */,
 				636BF1EA2C5D8EC900C1244C /* Battery.swift in Sources */,
 				636BF1EB2C5D8EC900C1244C /* Car.swift in Sources */,
+				4C4BF431831E40DDB81B5B12 /* Scooter.swift in Sources */,
 				636BF1EC2C5D8EC900C1244C /* HomeConnect.swift in Sources */,
 				636BF1EE2C5D8EC900C1244C /* Miele.swift in Sources */,
 				636BF1EF2C5D8EC900C1244C /* Robots.swift in Sources */,
@@ -1179,6 +1197,8 @@ MP0002000000000000000002 /* MarkdownParser.swift in Sources */,
 				AA0003000000000000000002 /* Chat.swift in Sources */,
 				AA0005000000000000000001 /* ChatView.swift in Sources */,
 				63610D2B2BB86F230048B9FF /* Car.swift in Sources */,
+				233E302E4A3E42AEA96D94E2 /* Scooter.swift in Sources */,
+				FC70519504B244809D095CEC /* ScooterDetailView.swift in Sources */,
 				63DBD7592B954486006603D0 /* HomeKitIntegration.swift in Sources */,
 				63610D352BB8864F0048B9FF /* CarDetailView.swift in Sources */,
 				63DBD75A2B954486006603D0 /* WeatherView.swift in Sources */,
@@ -1250,6 +1270,8 @@ MP0002000000000000000003 /* MarkdownParser.swift in Sources */,
 				2C8F07D87EFD2DA8DEFBB58F /* Chat.swift in Sources */,
 				F27145294822FFB5FE80E84F /* ChatService.swift in Sources */,
 				EE07E20294AB53EAC4703BE6 /* Car.swift in Sources */,
+				F0779E97B0AB462F8FA3C9F4 /* Scooter.swift in Sources */,
+				A8FDEEF5BAC3453BB825E1DF /* ScooterDetailView.swift in Sources */,
 				88A694EA13C5590830184818 /* CarDetailView.swift in Sources */,
 				4EE7C07CB284872F0B2165AB /* CarHelper.swift in Sources */,
 				92BB68B7C6E3ED9215465CAB /* DateTimeView.swift in Sources */,

--- a/FluxHaus.xcodeproj/project.pbxproj
+++ b/FluxHaus.xcodeproj/project.pbxproj
@@ -1344,11 +1344,11 @@ MP0002000000000000000004 /* MarkdownParser.swift in Sources */,
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.5;
+				MARKETING_VERSION = 1.8.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.davidjensenius.FluxHaus.Tests-macOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
@@ -1414,7 +1414,7 @@ MP0002000000000000000004 /* MarkdownParser.swift in Sources */,
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.5;
+				MARKETING_VERSION = 1.8.6;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -1475,7 +1475,7 @@ MP0002000000000000000004 /* MarkdownParser.swift in Sources */,
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.5;
+				MARKETING_VERSION = 1.8.6;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -1491,7 +1491,7 @@ MP0002000000000000000004 /* MarkdownParser.swift in Sources */,
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = FluxHaus.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
 				ENABLE_PREVIEWS = YES;
@@ -1503,7 +1503,7 @@ MP0002000000000000000004 /* MarkdownParser.swift in Sources */,
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.5;
+				MARKETING_VERSION = 1.8.6;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus;
 				PRODUCT_NAME = FluxHaus;
 				SDKROOT = iphoneos;
@@ -1524,7 +1524,7 @@ MP0002000000000000000004 /* MarkdownParser.swift in Sources */,
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = FluxHaus.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
 				ENABLE_PREVIEWS = YES;
@@ -1536,7 +1536,7 @@ MP0002000000000000000004 /* MarkdownParser.swift in Sources */,
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.5;
+				MARKETING_VERSION = 1.8.6;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus;
 				PRODUCT_NAME = FluxHaus;
 				SDKROOT = iphoneos;
@@ -1565,7 +1565,7 @@ MP0002000000000000000004 /* MarkdownParser.swift in Sources */,
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.5;
+				MARKETING_VERSION = 1.8.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.davidjensenius.Tests-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1592,7 +1592,7 @@ MP0002000000000000000004 /* MarkdownParser.swift in Sources */,
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.5;
+				MARKETING_VERSION = 1.8.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.davidjensenius.Tests-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1615,7 +1615,7 @@ MP0002000000000000000004 /* MarkdownParser.swift in Sources */,
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_ENTITLEMENTS = FluxWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
@@ -1631,7 +1631,7 @@ MP0002000000000000000004 /* MarkdownParser.swift in Sources */,
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.8.5;
+				MARKETING_VERSION = 1.8.6;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus.FluxWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1654,7 +1654,7 @@ MP0002000000000000000004 /* MarkdownParser.swift in Sources */,
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_ENTITLEMENTS = FluxWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
@@ -1670,7 +1670,7 @@ MP0002000000000000000004 /* MarkdownParser.swift in Sources */,
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.8.5;
+				MARKETING_VERSION = 1.8.6;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus.FluxWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1693,7 +1693,7 @@ MP0002000000000000000004 /* MarkdownParser.swift in Sources */,
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_ENTITLEMENTS = VisionOS/VisionOS.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"VisionOS/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
@@ -1707,7 +1707,7 @@ MP0002000000000000000004 /* MarkdownParser.swift in Sources */,
 					"@executable_path/Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.8.5;
+				MARKETING_VERSION = 1.8.6;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus;
 				PRODUCT_MODULE_NAME = FluxHaus;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1731,7 +1731,7 @@ MP0002000000000000000004 /* MarkdownParser.swift in Sources */,
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_ENTITLEMENTS = VisionOS/VisionOS.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"VisionOS/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
@@ -1745,7 +1745,7 @@ MP0002000000000000000004 /* MarkdownParser.swift in Sources */,
 					"@executable_path/Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.8.5;
+				MARKETING_VERSION = 1.8.6;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus;
 				PRODUCT_MODULE_NAME = FluxHaus;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1767,11 +1767,11 @@ MP0002000000000000000004 /* MarkdownParser.swift in Sources */,
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 1;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.8.5;
+				MARKETING_VERSION = 1.8.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jensenius.fluxhaus.VisionOSTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = xros;
@@ -1793,11 +1793,11 @@ MP0002000000000000000004 /* MarkdownParser.swift in Sources */,
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 1;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.8.5;
+				MARKETING_VERSION = 1.8.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jensenius.fluxhaus.VisionOSTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = xros;
@@ -1822,7 +1822,7 @@ MP0002000000000000000004 /* MarkdownParser.swift in Sources */,
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 9JALHNGRBQ;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -1844,7 +1844,7 @@ MP0002000000000000000004 /* MarkdownParser.swift in Sources */,
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.5;
+				MARKETING_VERSION = 1.8.6;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus;
 				PRODUCT_NAME = FluxHaus;
 				SDKROOT = macosx;
@@ -1862,7 +1862,7 @@ MP0002000000000000000004 /* MarkdownParser.swift in Sources */,
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 9JALHNGRBQ;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -1884,7 +1884,7 @@ MP0002000000000000000004 /* MarkdownParser.swift in Sources */,
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.5;
+				MARKETING_VERSION = 1.8.6;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus;
 				PRODUCT_NAME = FluxHaus;
 				SDKROOT = macosx;
@@ -1896,11 +1896,11 @@ MP0002000000000000000004 /* MarkdownParser.swift in Sources */,
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.5;
+				MARKETING_VERSION = 1.8.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.davidjensenius.FluxHaus.Tests-macOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;

--- a/Shared/Api.swift
+++ b/Shared/Api.swift
@@ -104,6 +104,25 @@ struct MockData {
             programName: "Cotton 60",
             status: "Running",
             inUse: true
+        ),
+        scooter: ScooterSummary(
+            timestamp: "2024-12-13T11:50:00Z",
+            battery: 85,
+            estimatedRange: 42.5,
+            odometer: 1234.5,
+            totalRideTime: 36000,
+            batteryCycles: 42,
+            lastRide: ScooterLastRide(
+                date: "2024-12-13T10:00:00Z",
+                endDate: "2024-12-13T10:30:00Z",
+                distance: 12.5,
+                maxSpeed: 65.0,
+                avgSpeed: 38.2,
+                batteryUsed: 15,
+                startBattery: 100,
+                endBattery: 85,
+                gearMode: 3
+            )
         )
     )
 
@@ -135,6 +154,13 @@ struct MockData {
         let api = createApi()
         robots.setApiResponse(apiResponse: api)
         return robots
+    }
+
+    static func createScooter() -> Scooter {
+        let scooter = Scooter()
+        let api = createApi()
+        scooter.setApiResponse(apiResponse: api)
+        return scooter
     }
 
     static func createBattery() -> Battery {

--- a/Shared/AppliancesView.swift
+++ b/Shared/AppliancesView.swift
@@ -19,6 +19,7 @@ struct Appliances: View {
     var locationManager: LocationManager
 
     @State private var showCarModal: Bool = false
+    @State private var showScooterModal: Bool = false
     @State private var showBroomBotModal: Bool = false
     @State private var showMopBotModal: Bool = false
     @State private var showApplianceModal: [String: Bool] = [:]
@@ -114,6 +115,8 @@ struct Appliances: View {
                                         self.car.apiResponse = self.apiResponse
                                         self.car.fetchCarDetails()
                                         self.showCarModal = true
+                                    } else if theAppliances[app].name == "Scooter" {
+                                        self.showScooterModal = true
                                     } else if theAppliances[app].name == "MopBot" {
                                         self.showMopBotModal = true
                                     } else if theAppliances[app].name == "BroomBot" {
@@ -132,6 +135,15 @@ struct Appliances: View {
         .onAppear(perform: {_ = self.updateTimer; fetchAppliances()})
         .sheet(isPresented: self.$showCarModal) {
             CarDetailView(car: car, locationManager: locationManager)
+        }
+        .sheet(isPresented: self.$showScooterModal) {
+            ScooterDetailView(
+                scooter: {
+                    let scooter = Scooter()
+                    scooter.setApiResponse(apiResponse: apiResponse)
+                    return scooter
+                }()
+            )
         }
         .sheet(isPresented: self.$showBroomBotModal) {
             RobotDetailView(robot: robots.broomBot, robots: robots)
@@ -198,7 +210,7 @@ struct Appliances: View {
             let name = appliance.name
             let index = appliance.index
             switch name {
-            case "Car", "Battery":
+            case "Car", "Scooter", "Battery":
                 activeAppliances.append(appliance)
             case "MopBot":
                 if robots.mopBot.running != nil && (robots.mopBot.running == true || robots.mopBot.paused == true) {

--- a/Shared/AppliancesViewExtensions.swift
+++ b/Shared/AppliancesViewExtensions.swift
@@ -217,21 +217,9 @@ extension Appliances {
         if type == "Miele" {
             tAppliance = miele.appliances
         } else if type == "MopBot" {
-            if robots.mopBot.running != nil && (robots.mopBot.running == true || robots.mopBot.paused == true) {
-                return "On"
-            } else if robots.mopBot.running != nil && robots.mopBot.running == false {
-                return "Off"
-            } else {
-                return "Lost"
-            }
+            return robotStatus(robots.mopBot)
         } else if type == "BroomBot" {
-            if robots.broomBot.running != nil && (robots.broomBot.running == true || robots.broomBot.paused == true) {
-                return "On"
-            } else if robots.broomBot.running != nil && robots.broomBot.running == false {
-                return "Off"
-            } else {
-                return "Lost"
-            }
+            return robotStatus(robots.broomBot)
         } else if type == "Battery" {
             return "\(battery.percent)%"
         } else if type == "Car" {
@@ -249,6 +237,15 @@ extension Appliances {
             return tApplianceTimeRemaining(tAppliance: tAppliance, index: index)
         }
         return ""
+    }
+
+    private func robotStatus(_ robot: Robot) -> String {
+        if robot.running == true || robot.paused == true {
+            return "On"
+        } else if robot.running == false {
+            return "Off"
+        }
+        return "Lost"
     }
 
     private func scooterDetails() -> String {

--- a/Shared/AppliancesViewExtensions.swift
+++ b/Shared/AppliancesViewExtensions.swift
@@ -20,6 +20,8 @@ extension Appliances {
             return getBatteryIconColor()
         case "Car":
             return getCarIconColor()
+        case "Scooter":
+            return getScooterIconColor()
         default: // HomeConnect
             return getApplianceIconColor(appliances: hconn.appliances, index: index)
         }
@@ -54,6 +56,10 @@ extension Appliances {
         return Theme.Colors.textSecondary
     }
 
+    private func getScooterIconColor() -> Color {
+        return Theme.Colors.textSecondary
+    }
+
     private func getApplianceIconColor(appliances: [Appliance], index: Int) -> Color {
         if appliances.count > index {
             if appliances[index].inUse {
@@ -77,6 +83,8 @@ extension Appliances {
             return getDeviceIcon(battery: battery)
         } else if type == "Car" {
             return Image(systemName: "car")
+        } else if type == "Scooter" {
+            return Image(systemName: "scooter")
         } else {
             tAppliance = hconn.appliances
         }
@@ -113,6 +121,8 @@ extension Appliances {
             }
         } else if type == "Car" {
             return "Car"
+        } else if type == "Scooter" {
+            return "GT3 Pro"
         } else {
             tAppliance = hconn.appliances
         }
@@ -158,6 +168,8 @@ extension Appliances {
             return ""
         } else if type == "Car" {
             return carDetails(car: car)
+        } else if type == "Scooter" {
+            return scooterDetails()
         } else {
             tAppliance = hconn.appliances
         }
@@ -224,6 +236,11 @@ extension Appliances {
             return "\(battery.percent)%"
         } else if type == "Car" {
             return "\(car.vehicle.batteryLevel)%"
+        } else if type == "Scooter" {
+            if let battery = apiResponse.response?.scooter?.battery {
+                return "\(battery)%"
+            }
+            return "—"
         } else {
             tAppliance = hconn.appliances
         }
@@ -232,5 +249,18 @@ extension Appliances {
             return tApplianceTimeRemaining(tAppliance: tAppliance, index: index)
         }
         return ""
+    }
+
+    private func scooterDetails() -> String {
+        guard let scooter = apiResponse.response?.scooter else { return "" }
+        var text = ""
+        if let range = scooter.estimatedRange {
+            text += "Range \(String(format: "%.0f", range)) km"
+        }
+        if let timestamp = scooter.timestamp {
+            if !text.isEmpty { text += " | " }
+            text += "Updated \(relativeTimeString(from: timestamp))"
+        }
+        return text
     }
 }

--- a/Shared/LiveActivityManager.swift
+++ b/Shared/LiveActivityManager.swift
@@ -180,7 +180,7 @@ class LiveActivityManager {
             await activity.end(nil, dismissalPolicy: .immediate)
         }
 
-        // Clean up stale/ended/dismissed consolidated activities to unblock push-to-start
+        // If our tracked activity has ended, clear the reference
         if let activity = consolidatedActivity {
             switch activity.activityState {
             case .ended, .dismissed:
@@ -193,23 +193,28 @@ class LiveActivityManager {
             }
         }
 
-        // Adopt consolidated activity from push-to-start if we don't track it
-        if consolidatedActivity == nil {
-            for activity in Activity<FluxWidgetMultiAttributes>.activities
-            where activity.activityState == .active || activity.activityState == .stale {
-                consolidatedActivity = activity
-                observeActivityPushToken(activity: activity)
-                logger.info("Adopted consolidated Live Activity")
-                break
-            }
+        // Collect all active/stale consolidated activities
+        let liveActivities = Activity<FluxWidgetMultiAttributes>.activities.filter {
+            $0.activityState == .active || $0.activityState == .stale
         }
 
-        // End any EXTRA consolidated activities (dedup — only keep the one we track)
-        for activity in Activity<FluxWidgetMultiAttributes>.activities
-        where activity.id != consolidatedActivity?.id
-            && (activity.activityState == .active || activity.activityState == .stale) {
-            await activity.end(nil, dismissalPolicy: .immediate)
-            logger.info("Ended duplicate consolidated activity")
+        if consolidatedActivity != nil {
+            // We already track one — end any extras
+            for activity in liveActivities where activity.id != consolidatedActivity?.id {
+                nonisolated(unsafe) let activityRef = activity
+                await activityRef.end(nil, dismissalPolicy: .immediate)
+                logger.info("Ended duplicate consolidated activity")
+            }
+        } else if let first = liveActivities.first {
+            // Adopt the first live activity, end all others
+            consolidatedActivity = first
+            observeActivityPushToken(activity: first)
+            logger.info("Adopted consolidated Live Activity")
+            for activity in liveActivities.dropFirst() {
+                nonisolated(unsafe) let activityRef = activity
+                await activityRef.end(nil, dismissalPolicy: .immediate)
+                logger.info("Ended duplicate consolidated activity")
+            }
         }
     }
 
@@ -241,6 +246,13 @@ class LiveActivityManager {
     }
 
     private func startConsolidatedActivity(devices: [WidgetDevice]) {
+        // Safety: end any orphaned activities before starting a new one
+        for activity in Activity<FluxWidgetMultiAttributes>.activities
+        where activity.activityState == .active || activity.activityState == .stale {
+            nonisolated(unsafe) let activityRef = activity
+            Task { await activityRef.end(nil, dismissalPolicy: .immediate) }
+        }
+
         let attributes = FluxWidgetMultiAttributes(name: "Appliances")
         let state = FluxWidgetMultiAttributes.ContentState(devices: devices)
 

--- a/Shared/LoginStucts.swift
+++ b/Shared/LoginStucts.swift
@@ -433,6 +433,8 @@ public struct ScooterLastRide: Codable {
 
 public struct ScooterSummary: Codable {
     public let timestamp: String?
+    public let battery: Int?
+    public let estimatedRange: Double?
     public let odometer: Double?
     public let totalRideTime: Int?
     public let batteryCycles: Int?
@@ -440,12 +442,16 @@ public struct ScooterSummary: Codable {
 
     public init(
         timestamp: String? = nil,
+        battery: Int? = nil,
+        estimatedRange: Double? = nil,
         odometer: Double? = nil,
         totalRideTime: Int? = nil,
         batteryCycles: Int? = nil,
         lastRide: ScooterLastRide? = nil
     ) {
         self.timestamp = timestamp
+        self.battery = battery
+        self.estimatedRange = estimatedRange
         self.odometer = odometer
         self.totalRideTime = totalRideTime
         self.batteryCycles = batteryCycles

--- a/Shared/LoginStucts.swift
+++ b/Shared/LoginStucts.swift
@@ -366,6 +366,7 @@ public struct LoginResponse: Codable {
     public let dishwasher: DishWasher?
     public let dryer: WasherDryer?
     public let washer: WasherDryer?
+    public let scooter: ScooterSummary?
 
     public init(
         timestamp: String,
@@ -378,7 +379,8 @@ public struct LoginResponse: Codable {
         carOdometer: Double? = nil,
         dishwasher: DishWasher? = nil,
         dryer: WasherDryer? = nil,
-        washer: WasherDryer? = nil
+        washer: WasherDryer? = nil,
+        scooter: ScooterSummary? = nil
     ) {
         self.timestamp = timestamp
         self.favouriteHomeKit = favouriteHomeKit
@@ -391,6 +393,63 @@ public struct LoginResponse: Codable {
         self.dishwasher = dishwasher
         self.dryer = dryer
         self.washer = washer
+        self.scooter = scooter
+    }
+}
+
+public struct ScooterLastRide: Codable {
+    public let date: String?
+    public let endDate: String?
+    public let distance: Double?
+    public let maxSpeed: Double?
+    public let avgSpeed: Double?
+    public let batteryUsed: Int?
+    public let startBattery: Int?
+    public let endBattery: Int?
+    public let gearMode: Int?
+
+    public init(
+        date: String? = nil,
+        endDate: String? = nil,
+        distance: Double? = nil,
+        maxSpeed: Double? = nil,
+        avgSpeed: Double? = nil,
+        batteryUsed: Int? = nil,
+        startBattery: Int? = nil,
+        endBattery: Int? = nil,
+        gearMode: Int? = nil
+    ) {
+        self.date = date
+        self.endDate = endDate
+        self.distance = distance
+        self.maxSpeed = maxSpeed
+        self.avgSpeed = avgSpeed
+        self.batteryUsed = batteryUsed
+        self.startBattery = startBattery
+        self.endBattery = endBattery
+        self.gearMode = gearMode
+    }
+}
+
+public struct ScooterSummary: Codable {
+    public let timestamp: String?
+    public let odometer: Double?
+    public let totalRideTime: Int?
+    public let batteryCycles: Int?
+    public let lastRide: ScooterLastRide?
+
+    public init(
+        timestamp: String? = nil,
+        odometer: Double? = nil,
+        totalRideTime: Int? = nil,
+        batteryCycles: Int? = nil,
+        lastRide: ScooterLastRide? = nil
+    ) {
+        self.timestamp = timestamp
+        self.odometer = odometer
+        self.totalRideTime = totalRideTime
+        self.batteryCycles = batteryCycles
+        self.lastRide = lastRide
     }
 }
 

--- a/Shared/Scooter.swift
+++ b/Shared/Scooter.swift
@@ -25,9 +25,7 @@ import Foundation
     func fetchScooterDetails() {
         if let response = apiResponse?.response,
            let scooterData = response.scooter {
-            DispatchQueue.main.async {
-                self.summary = scooterData
-            }
+            self.summary = scooterData
         }
     }
 

--- a/Shared/Scooter.swift
+++ b/Shared/Scooter.swift
@@ -50,13 +50,21 @@ import Foundation
 
     var formattedLastRideDate: String {
         guard let dateStr = summary.lastRide?.date else { return "—" }
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        guard let date = formatter.date(from: dateStr)
+        guard let date = Self.isoFormatter.date(from: dateStr)
                 ?? ISO8601DateFormatter().date(from: dateStr) else { return dateStr }
-        let display = DateFormatter()
-        display.dateStyle = .medium
-        display.timeStyle = .short
-        return display.string(from: date)
+        return Self.displayFormatter.string(from: date)
     }
 }
+
+private extension Scooter {
+    private static let isoFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+    private static let displayFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        return formatter
+    }()

--- a/Shared/Scooter.swift
+++ b/Shared/Scooter.swift
@@ -1,0 +1,62 @@
+//
+//  Scooter.swift
+//  FluxHaus
+//
+
+import Foundation
+
+@MainActor
+@Observable class Scooter {
+    var apiResponse: Api?
+    var summary = ScooterSummary()
+
+    private static let gearNames: [Int: String] = [1: "Eco", 2: "Standard", 3: "Sport", 4: "Race"]
+
+    static func gearName(_ mode: Int?) -> String {
+        guard let mode = mode else { return "Unknown" }
+        return gearNames[mode] ?? "Mode \(mode)"
+    }
+
+    func setApiResponse(apiResponse: Api) {
+        self.apiResponse = apiResponse
+        fetchScooterDetails()
+    }
+
+    func fetchScooterDetails() {
+        if let response = apiResponse?.response,
+           let scooterData = response.scooter {
+            DispatchQueue.main.async {
+                self.summary = scooterData
+            }
+        }
+    }
+
+    var formattedOdometer: String {
+        guard let odo = summary.odometer else { return "—" }
+        return String(format: "%.1f km", odo)
+    }
+
+    var formattedTotalRideTime: String {
+        guard let seconds = summary.totalRideTime else { return "—" }
+        let hours = seconds / 3600
+        let minutes = (seconds % 3600) / 60
+        return "\(hours)h \(minutes)m"
+    }
+
+    var formattedLastRideDistance: String {
+        guard let dist = summary.lastRide?.distance else { return "—" }
+        return dist < 1 ? String(format: "%.0f m", dist * 1000) : String(format: "%.1f km", dist)
+    }
+
+    var formattedLastRideDate: String {
+        guard let dateStr = summary.lastRide?.date else { return "—" }
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        guard let date = formatter.date(from: dateStr)
+                ?? ISO8601DateFormatter().date(from: dateStr) else { return dateStr }
+        let display = DateFormatter()
+        display.dateStyle = .medium
+        display.timeStyle = .short
+        return display.string(from: date)
+    }
+}

--- a/Shared/Scooter.swift
+++ b/Shared/Scooter.swift
@@ -57,14 +57,15 @@ import Foundation
 }
 
 private extension Scooter {
-    private static let isoFormatter: ISO8601DateFormatter = {
+    static let isoFormatter: ISO8601DateFormatter = {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         return formatter
     }()
-    private static let displayFormatter: DateFormatter = {
+    static let displayFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateStyle = .medium
         formatter.timeStyle = .short
         return formatter
     }()
+}

--- a/Shared/ScooterDetailView.swift
+++ b/Shared/ScooterDetailView.swift
@@ -35,6 +35,18 @@ struct ScooterDetailView: View {
                                     .foregroundColor(Theme.Colors.textSecondary)
                             }
 
+                            if let battery = scooter.summary.battery {
+                                HStack(spacing: 4) {
+                                    Text("Battery: \(battery)%")
+                                    if let range = scooter.summary.estimatedRange {
+                                        Text("·")
+                                        Text(String(format: "%.0f km", range))
+                                    }
+                                }
+                                .font(Theme.Fonts.bodyLarge)
+                                .foregroundColor(Theme.Colors.textPrimary)
+                            }
+
                             HStack(spacing: 16) {
                                 Label(scooter.formattedOdometer, systemImage: "gauge.with.dots.needle.67percent")
                                     .foregroundColor(Theme.Colors.textPrimary)

--- a/Shared/ScooterDetailView.swift
+++ b/Shared/ScooterDetailView.swift
@@ -55,7 +55,11 @@ struct ScooterDetailView: View {
                     }
                     .padding()
                     .frame(maxWidth: .infinity, alignment: .leading)
+                    #if os(visionOS)
+                    .glassBackgroundEffect()
+                    #else
                     .background(Theme.Colors.secondaryBackground)
+                    #endif
                     .cornerRadius(12)
 
                     // Last Ride Section

--- a/Shared/ScooterDetailView.swift
+++ b/Shared/ScooterDetailView.swift
@@ -1,0 +1,123 @@
+//
+//  ScooterDetailView.swift
+//  FluxHaus
+//
+
+import SwiftUI
+
+struct ScooterDetailView: View {
+    var scooter: Scooter
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: 20) {
+                    #if !os(macOS)
+                    HStack {
+                        Image(systemName: "scooter")
+                        Text("GT3 Pro")
+                    }
+                    .font(Theme.Fonts.headerXL())
+                    .foregroundColor(Theme.Colors.textPrimary)
+                    .padding(.top)
+                    #endif
+
+                    // Status Section
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text("Status")
+                            .font(Theme.Fonts.headerLarge())
+                            .foregroundColor(Theme.Colors.textPrimary)
+
+                        VStack(alignment: .leading, spacing: 8) {
+                            if let timestamp = scooter.summary.timestamp {
+                                Text("Updated \(relativeTimeString(from: timestamp))")
+                                    .font(Theme.Fonts.caption)
+                                    .foregroundColor(Theme.Colors.textSecondary)
+                            }
+
+                            HStack(spacing: 16) {
+                                Label(scooter.formattedOdometer, systemImage: "gauge.with.dots.needle.67percent")
+                                    .foregroundColor(Theme.Colors.textPrimary)
+                                if let cycles = scooter.summary.batteryCycles {
+                                    Label("\(cycles) cycles", systemImage: "battery.100percent.circle")
+                                        .foregroundColor(Theme.Colors.textPrimary)
+                                }
+                            }
+                            .font(Theme.Fonts.bodyMedium)
+
+                            Label(
+                                "Total ride time: \(scooter.formattedTotalRideTime)",
+                                systemImage: "clock"
+                            )
+                            .font(Theme.Fonts.bodyMedium)
+                            .foregroundColor(Theme.Colors.textPrimary)
+                        }
+                    }
+                    .padding()
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Theme.Colors.secondaryBackground)
+                    .cornerRadius(12)
+
+                    // Last Ride Section
+                    if let lastRide = scooter.summary.lastRide {
+                        VStack(alignment: .leading, spacing: 12) {
+                            Text("Last Ride")
+                                .font(Theme.Fonts.headerLarge())
+                                .foregroundColor(Theme.Colors.textPrimary)
+
+                            VStack(alignment: .leading, spacing: 8) {
+                                Text(scooter.formattedLastRideDate)
+                                    .font(Theme.Fonts.caption)
+                                    .foregroundColor(Theme.Colors.textSecondary)
+
+                                HStack(spacing: 16) {
+                                    Label(
+                                        scooter.formattedLastRideDistance,
+                                        systemImage: "point.topleft.down.to.point.bottomright.curvepath"
+                                    )
+                                    .foregroundColor(Theme.Colors.textPrimary)
+
+                                    if let maxSpeed = lastRide.maxSpeed {
+                                        Label(
+                                            String(format: "%.1f km/h", maxSpeed),
+                                            systemImage: "speedometer"
+                                        )
+                                        .foregroundColor(Theme.Colors.textPrimary)
+                                    }
+                                }
+                                .font(Theme.Fonts.bodyMedium)
+
+                                HStack(spacing: 16) {
+                                    if let startBatt = lastRide.startBattery,
+                                       let endBatt = lastRide.endBattery {
+                                        Label(
+                                            "\(startBatt)% → \(endBatt)%",
+                                            systemImage: "battery.75percent"
+                                        )
+                                        .foregroundColor(Theme.Colors.textPrimary)
+                                    }
+
+                                    Label(
+                                        Scooter.gearName(lastRide.gearMode),
+                                        systemImage: "gearshape"
+                                    )
+                                    .foregroundColor(Theme.Colors.textPrimary)
+                                }
+                                .font(Theme.Fonts.bodyMedium)
+                            }
+                        }
+                        .padding()
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(Theme.Colors.secondaryBackground)
+                        .cornerRadius(12)
+                    }
+                }
+                .padding()
+            }
+            .background(Theme.Colors.background)
+            #if os(macOS)
+            .navigationTitle("GT3 Pro")
+            #endif
+        }
+    }
+}

--- a/Shared/ScooterDetailView.swift
+++ b/Shared/ScooterDetailView.swift
@@ -124,7 +124,11 @@ struct ScooterDetailView: View {
                         }
                         .padding()
                         .frame(maxWidth: .infinity, alignment: .leading)
+                        #if os(visionOS)
+                        .glassBackgroundEffect()
+                        #else
                         .background(Theme.Colors.secondaryBackground)
+                        #endif
                         .cornerRadius(12)
                     }
                 }

--- a/Tests iOS/MockDataUITests.swift
+++ b/Tests iOS/MockDataUITests.swift
@@ -138,6 +138,7 @@ struct ViewSmokeTests {
             robots: robots,
             battery: MockData.createBattery(),
             car: car,
+            scooter: MockData.createScooter(),
             apiResponse: MockData.createApi()
         )
 
@@ -432,7 +433,8 @@ struct NilDataResilienceTests {
         let view = ContentView(
             fluxHausConsts: FluxHausConsts(),
             hconn: hconn, miele: miele, robots: robots,
-            battery: Battery(), car: car, apiResponse: api
+            battery: Battery(), car: car,
+            scooter: MockData.createScooter(), apiResponse: api
         )
         let controller = UIHostingController(rootView: view)
         controller.loadViewIfNeeded()

--- a/Tests macOS/Tests_macOS_ViewTests.swift
+++ b/Tests macOS/Tests_macOS_ViewTests.swift
@@ -79,6 +79,7 @@ struct MacOSViewSmokeTests {
             robots: robots,
             battery: MockData.createBattery(),
             car: car,
+            scooter: MockData.createScooter(),
             apiResponse: MockData.createApi(),
             chat: Chat()
         )
@@ -133,6 +134,7 @@ struct MacOSViewSmokeTests {
             robots: robots,
             battery: MockData.createBattery(),
             car: car,
+            scooter: MockData.createScooter(),
             apiResponse: MockData.createApi(),
             locationManager: LocationManager(),
             radarService: RadarService(),
@@ -417,7 +419,9 @@ struct MacOSNilDataResilienceTests {
         let view = ContentView(
             fluxHausConsts: FluxHausConsts(),
             hconn: hconn, miele: miele, robots: robots,
-            battery: Battery(), car: car, apiResponse: api, chat: Chat()
+            battery: Battery(), car: car,
+            scooter: MockData.createScooter(),
+            apiResponse: api, chat: Chat()
         )
         let controller = NSHostingController(rootView: view)
         controller.loadView()
@@ -440,7 +444,9 @@ struct MacOSNilDataResilienceTests {
         let view = DashboardView(
             fluxHausConsts: FluxHausConsts(),
             hconn: hconn, miele: miele, robots: robots,
-            battery: Battery(), car: car, apiResponse: api,
+            battery: Battery(), car: car,
+            scooter: MockData.createScooter(),
+            apiResponse: api,
             locationManager: LocationManager(),
             radarService: RadarService(),
             onNavigate: { _ in }

--- a/Tests macOS/Tests_macOS_ViewTests.swift
+++ b/Tests macOS/Tests_macOS_ViewTests.swift
@@ -173,12 +173,13 @@ struct SidebarItemTests {
     @Test("SidebarItem has all expected cases")
     func testAllCases() {
         let items = SidebarItem.allCases
-        #expect(items.count == 7)
+        #expect(items.count == 8)
         #expect(items.contains(.dashboard))
         #expect(items.contains(.weather))
         #expect(items.contains(.scenes))
         #expect(items.contains(.appliances))
         #expect(items.contains(.car))
+        #expect(items.contains(.scooter))
         #expect(items.contains(.robots))
         #expect(items.contains(.assistant))
     }
@@ -190,6 +191,7 @@ struct SidebarItemTests {
         #expect(SidebarItem.scenes.rawValue == "Scenes")
         #expect(SidebarItem.appliances.rawValue == "Appliances")
         #expect(SidebarItem.car.rawValue == "Car")
+        #expect(SidebarItem.scooter.rawValue == "Scooter")
         #expect(SidebarItem.robots.rawValue == "Robots")
         #expect(SidebarItem.assistant.rawValue == "Assistant")
     }
@@ -201,6 +203,7 @@ struct SidebarItemTests {
         #expect(SidebarItem.scenes.icon == "lightbulb.fill")
         #expect(SidebarItem.appliances.icon == "washer.fill")
         #expect(SidebarItem.car.icon == "car.fill")
+        #expect(SidebarItem.scooter.icon == "scooter")
         #expect(SidebarItem.robots.icon == "fan.fill")
         #expect(
             SidebarItem.assistant.icon

--- a/VisionOS/ContentView.swift
+++ b/VisionOS/ContentView.swift
@@ -16,6 +16,7 @@ struct ContentView: View {
     var robots: Robots
     var battery: Battery
     var car: Car
+    var scooter: Scooter
     var apiResponse: Api
     @State private var whereWeAre = WhereWeAre()
     @StateObject private var locationManager = LocationManager()
@@ -41,6 +42,9 @@ struct ContentView: View {
             carTab
                 .tabItem { Label("Car", systemImage: "car.fill") }
                 .tag("Car")
+            scooterTab
+                .tabItem { Label("Scooter", systemImage: "scooter") }
+                .tag("Scooter")
             RobotsListView(robots: robots)
                 .tabItem { Label("Robots", systemImage: "fan.fill") }
                 .tag("Robots")
@@ -100,6 +104,10 @@ struct ContentView: View {
         CarDetailView(car: car, locationManager: locationManager)
     }
 
+    private var scooterTab: some View {
+        ScooterDetailView(scooter: scooter)
+    }
+
     private var appliancesTab: some View {
         AppliancesDetailView(
             hconn: hconn,
@@ -116,8 +124,9 @@ struct ContentView: View {
             Button("") { selectedTab = "Scenes" }.keyboardShortcut("3")
             Button("") { selectedTab = "Appliances" }.keyboardShortcut("4")
             Button("") { selectedTab = "Car" }.keyboardShortcut("5")
-            Button("") { selectedTab = "Robots" }.keyboardShortcut("6")
-            Button("") { selectedTab = "Assistant" }.keyboardShortcut("7")
+            Button("") { selectedTab = "Scooter" }.keyboardShortcut("6")
+            Button("") { selectedTab = "Robots" }.keyboardShortcut("7")
+            Button("") { selectedTab = "Assistant" }.keyboardShortcut("8")
         }
         .frame(width: 0, height: 0)
         .opacity(0)
@@ -137,6 +146,7 @@ struct ContentView: View {
         robots: MockData.createRobots(),
         battery: MockData.createBattery(),
         car: MockData.createCar(),
+        scooter: Scooter(),
         apiResponse: MockData.createApi()
     )
 }

--- a/VisionOS/VisionOSApp.swift
+++ b/VisionOS/VisionOSApp.swift
@@ -84,48 +84,46 @@ struct VisionOSApp: App {
                             }
                         }
                 } else {
-                    guard let hconn = hconn,
-                          let miele = miele,
-                          let robots = robots,
-                          let battery = battery,
-                          let car = car,
-                          let scooter = scooter else {
-                        return
-                    }
-
-                    ContentView(
-                        fluxHausConsts: fluxHausConsts,
-                        hconn: hconn,
-                        miele: miele,
-                        robots: robots,
-                        battery: battery,
-                        car: car,
-                        scooter: scooter,
-                        apiResponse: self.apiResponse
-                    )
-                    .onReceive(NotificationCenter.default.publisher(for: Notification.Name.logout)) { object in
-                        if (object.userInfo?["logout"]) != nil {
-                            DispatchQueue.main.async {
-                                self.whereWeAre = WhereWeAre()
+                    if let hconn = hconn,
+                       let miele = miele,
+                       let robots = robots,
+                       let battery = battery,
+                       let car = car,
+                       let scooter = scooter {
+                        ContentView(
+                            fluxHausConsts: fluxHausConsts,
+                            hconn: hconn,
+                            miele: miele,
+                            robots: robots,
+                            battery: battery,
+                            car: car,
+                            scooter: scooter,
+                            apiResponse: self.apiResponse
+                        )
+                        .onReceive(NotificationCenter.default.publisher(for: Notification.Name.logout)) { object in
+                            if (object.userInfo?["logout"]) != nil {
+                                DispatchQueue.main.async {
+                                    self.whereWeAre = WhereWeAre()
+                                }
                             }
                         }
-                    }
-                    .onReceive(NotificationCenter.default.publisher(for: Notification.Name.dataUpdated)) { object in
-                        if let response = object.userInfo?["data"] as? LoginResponse {
-                            self.apiResponse.setApiResponse(apiResponse: response)
-                            robots?.setApiResponse(apiResponse: self.apiResponse)
-                            hconn?.setApiResponse(apiResponse: self.apiResponse)
-                            miele?.setApiResponse(apiResponse: self.apiResponse)
-                            car?.setApiResponse(apiResponse: self.apiResponse)
-                            scooter?.setApiResponse(apiResponse: self.apiResponse)
-                        }
-                    }
-                    .onReceive(timer) {_ in
-                        if AuthManager.shared.isSignedIn {
-                            Task {
-                                _ = await AuthManager.shared.ensureValidToken()
+                        .onReceive(NotificationCenter.default.publisher(for: Notification.Name.dataUpdated)) { object in
+                            if let response = object.userInfo?["data"] as? LoginResponse {
+                                self.apiResponse.setApiResponse(apiResponse: response)
+                                robots.setApiResponse(apiResponse: self.apiResponse)
+                                hconn.setApiResponse(apiResponse: self.apiResponse)
+                                miele.setApiResponse(apiResponse: self.apiResponse)
+                                car.setApiResponse(apiResponse: self.apiResponse)
+                                scooter.setApiResponse(apiResponse: self.apiResponse)
                             }
-                            queryFlux(password: WhereWeAre.getPassword() ?? "")
+                        }
+                        .onReceive(timer) {_ in
+                            if AuthManager.shared.isSignedIn {
+                                Task {
+                                    _ = await AuthManager.shared.ensureValidToken()
+                                }
+                                queryFlux(password: WhereWeAre.getPassword() ?? "")
+                            }
                         }
                     }
                 }

--- a/VisionOS/VisionOSApp.swift
+++ b/VisionOS/VisionOSApp.swift
@@ -16,6 +16,7 @@ private let appLogger = Logger(subsystem: "io.fluxhaus.FluxHaus", category: "Vis
 @MainActor var robots: Robots?
 @MainActor var battery: Battery?
 @MainActor var car: Car?
+@MainActor var scooter: Scooter?
 
 @main
 struct VisionOSApp: App {
@@ -78,6 +79,7 @@ struct VisionOSApp: App {
                                 loadRobots()
                                 loadBattery()
                                 loadCar()
+                                loadScooter()
                                 loadHomeConnect()
                             }
                         }
@@ -89,6 +91,7 @@ struct VisionOSApp: App {
                         robots: robots!,
                         battery: battery!,
                         car: car!,
+                        scooter: scooter!,
                         apiResponse: self.apiResponse
                     )
                     .onReceive(NotificationCenter.default.publisher(for: Notification.Name.logout)) { object in
@@ -105,6 +108,7 @@ struct VisionOSApp: App {
                             hconn?.setApiResponse(apiResponse: self.apiResponse)
                             miele?.setApiResponse(apiResponse: self.apiResponse)
                             car?.setApiResponse(apiResponse: self.apiResponse)
+                            scooter?.setApiResponse(apiResponse: self.apiResponse)
                         }
                     }
                     .onReceive(timer) {_ in
@@ -168,5 +172,10 @@ struct VisionOSApp: App {
     func loadCar() {
         car = Car()
         car?.setApiResponse(apiResponse: self.apiResponse)
+    }
+
+    func loadScooter() {
+        scooter = Scooter()
+        scooter?.setApiResponse(apiResponse: self.apiResponse)
     }
 }

--- a/VisionOS/VisionOSApp.swift
+++ b/VisionOS/VisionOSApp.swift
@@ -84,14 +84,23 @@ struct VisionOSApp: App {
                             }
                         }
                 } else {
+                    guard let hconn = hconn,
+                          let miele = miele,
+                          let robots = robots,
+                          let battery = battery,
+                          let car = car,
+                          let scooter = scooter else {
+                        return
+                    }
+
                     ContentView(
                         fluxHausConsts: fluxHausConsts,
-                        hconn: hconn!,
-                        miele: miele!,
-                        robots: robots!,
-                        battery: battery!,
-                        car: car!,
-                        scooter: scooter!,
+                        hconn: hconn,
+                        miele: miele,
+                        robots: robots,
+                        battery: battery,
+                        car: car,
+                        scooter: scooter,
                         apiResponse: self.apiResponse
                     )
                     .onReceive(NotificationCenter.default.publisher(for: Notification.Name.logout)) { object in

--- a/iOS/ContentView.swift
+++ b/iOS/ContentView.swift
@@ -14,6 +14,7 @@ struct ContentView: View {
     var robots: Robots
     var battery: Battery
     var car: Car
+    var scooter: Scooter
     var apiResponse: Api
     @State private var whereWeAre = WhereWeAre()
     @StateObject private var locationManager = LocationManager()
@@ -43,6 +44,10 @@ struct ContentView: View {
                 carTab
             }
             .customizationID("car")
+            Tab("Scooter", systemImage: "scooter", value: "scooter") {
+                scooterTab
+            }
+            .customizationID("scooter")
             TabSection {
                 Tab("Appliances", systemImage: "washer.fill", value: "appliances") {
                     appliancesTab
@@ -116,6 +121,10 @@ struct ContentView: View {
         CarDetailView(car: car, locationManager: locationManager)
     }
 
+    private var scooterTab: some View {
+        ScooterDetailView(scooter: scooter)
+    }
+
     private var scenesTab: some View {
         SceneView(favouriteScenes: fluxHausConsts.favouriteScenes)
     }
@@ -158,10 +167,11 @@ struct ContentView: View {
             Button("") { selectedTab = "weather" }.keyboardShortcut("2")
             Button("") { selectedTab = "assistant" }.keyboardShortcut("3")
             Button("") { selectedTab = "car" }.keyboardShortcut("4")
-            Button("") { selectedTab = "appliances" }.keyboardShortcut("5")
-            Button("") { selectedTab = "scenes" }.keyboardShortcut("6")
-            Button("") { selectedTab = "robots" }.keyboardShortcut("7")
-            Button("") { selectedTab = "settings" }.keyboardShortcut("8")
+            Button("") { selectedTab = "scooter" }.keyboardShortcut("5")
+            Button("") { selectedTab = "appliances" }.keyboardShortcut("6")
+            Button("") { selectedTab = "scenes" }.keyboardShortcut("7")
+            Button("") { selectedTab = "robots" }.keyboardShortcut("8")
+            Button("") { selectedTab = "settings" }.keyboardShortcut("9")
         }
         .frame(width: 0, height: 0)
         .opacity(0)
@@ -181,6 +191,7 @@ struct ContentView: View {
         robots: MockData.createRobots(),
         battery: MockData.createBattery(),
         car: MockData.createCar(),
+        scooter: Scooter(),
         apiResponse: MockData.createApi()
     )
 }

--- a/iOS/FluxHausApp.swift
+++ b/iOS/FluxHausApp.swift
@@ -123,6 +123,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 @MainActor var robots: Robots?
 @MainActor var battery: Battery?
 @MainActor var car: Car?
+@MainActor var scooter: Scooter?
 
 @main
 struct FluxHausApp: App {
@@ -190,10 +191,11 @@ struct FluxHausApp: App {
                                 loadRobots()
                                 loadBattery()
                                 loadCar()
+                                loadScooter()
                                 loadHomeConnect()
                             }
                         }
-                } else if let hconn, let miele, let robots, let car {
+                } else if let hconn, let miele, let robots, let car, let scooter {
                     ContentView(
                         fluxHausConsts: fluxHausConsts,
                         hconn: hconn,
@@ -201,6 +203,7 @@ struct FluxHausApp: App {
                         robots: robots,
                         battery: battery,
                         car: car,
+                        scooter: scooter,
                         apiResponse: self.apiResponse
                     )
                     .onReceive(NotificationCenter.default.publisher(for: Notification.Name.logout)) { object in
@@ -217,6 +220,7 @@ struct FluxHausApp: App {
                             hconn.setApiResponse(apiResponse: self.apiResponse)
                             miele.setApiResponse(apiResponse: self.apiResponse)
                             car.setApiResponse(apiResponse: self.apiResponse)
+                            scooter.setApiResponse(apiResponse: self.apiResponse)
                             updateLiveActivities(response: response)
                         }
                     }
@@ -277,8 +281,10 @@ struct FluxHausApp: App {
                     .keyboardShortcut("3", modifiers: .command)
                 Button("Car") { postNavigation("car") }
                     .keyboardShortcut("4", modifiers: .command)
-                Button("Appliances") { postNavigation("appliances") }
+                Button("Scooter") { postNavigation("scooter") }
                     .keyboardShortcut("5", modifiers: .command)
+                Button("Appliances") { postNavigation("appliances") }
+                    .keyboardShortcut("6", modifiers: .command)
 
                 Divider()
 
@@ -310,6 +316,11 @@ struct FluxHausApp: App {
     func loadCar() {
         car = Car()
         car?.setApiResponse(apiResponse: self.apiResponse)
+    }
+
+    func loadScooter() {
+        scooter = Scooter()
+        scooter?.setApiResponse(apiResponse: self.apiResponse)
     }
 
     func updateLiveActivities(response: LoginResponse) {

--- a/macOS/ContentView.swift
+++ b/macOS/ContentView.swift
@@ -13,6 +13,7 @@ enum SidebarItem: String, CaseIterable, Identifiable {
     case scenes = "Scenes"
     case appliances = "Appliances"
     case car = "Car"
+    case scooter = "Scooter"
     case robots = "Robots"
     case assistant = "Assistant"
 
@@ -25,6 +26,7 @@ enum SidebarItem: String, CaseIterable, Identifiable {
         case .scenes: return "lightbulb.fill"
         case .appliances: return "washer.fill"
         case .car: return "car.fill"
+        case .scooter: return "scooter"
         case .robots: return "fan.fill"
         case .assistant: return "bubble.left.and.bubble.right.fill"
         }
@@ -38,6 +40,7 @@ struct ContentView: View {
     var robots: Robots
     var battery: Battery
     var car: Car
+    var scooter: Scooter
     var apiResponse: Api
     var chat: Chat
     @StateObject private var locationManager = LocationManager()
@@ -93,8 +96,9 @@ struct ContentView: View {
             Button("") { selectedItem = .scenes }.keyboardShortcut("3")
             Button("") { selectedItem = .appliances }.keyboardShortcut("4")
             Button("") { selectedItem = .car }.keyboardShortcut("5")
-            Button("") { selectedItem = .robots }.keyboardShortcut("6")
-            Button("") { selectedItem = .assistant }.keyboardShortcut("7")
+            Button("") { selectedItem = .scooter }.keyboardShortcut("6")
+            Button("") { selectedItem = .robots }.keyboardShortcut("7")
+            Button("") { selectedItem = .assistant }.keyboardShortcut("8")
         }
         .frame(width: 0, height: 0)
         .opacity(0)
@@ -111,6 +115,7 @@ struct ContentView: View {
                 robots: robots,
                 battery: battery,
                 car: car,
+                scooter: scooter,
                 apiResponse: apiResponse,
                 locationManager: locationManager,
                 radarService: radarService,
@@ -131,6 +136,9 @@ struct ContentView: View {
         case .car:
             CarDetailView(car: car, locationManager: locationManager)
                 .navigationTitle("Car")
+        case .scooter:
+            ScooterDetailView(scooter: scooter)
+                .navigationTitle("Scooter")
         case .robots:
             RobotsMacView(robots: robots)
                 .navigationTitle("Robots")
@@ -437,6 +445,7 @@ struct RobotsMacView: View {
         robots: MockData.createRobots(),
         battery: MockData.createBattery(),
         car: MockData.createCar(),
+        scooter: Scooter(),
         apiResponse: MockData.createApi(),
         chat: Chat()
     )

--- a/macOS/DashboardView.swift
+++ b/macOS/DashboardView.swift
@@ -14,6 +14,7 @@ struct DashboardView: View {
     var robots: Robots
     var battery: Battery
     var car: Car
+    var scooter: Scooter
     var apiResponse: Api
     @ObservedObject var locationManager: LocationManager
     var radarService: RadarService
@@ -71,6 +72,7 @@ struct DashboardView: View {
             ))
         }
         cards.append(DeviceCard(id: "car", isActive: false, priority: 1, view: AnyView(carCard)))
+        cards.append(DeviceCard(id: "scooter", isActive: false, priority: 1, view: AnyView(scooterCard)))
         return cards.sorted { $0.priority > $1.priority }
     }
 
@@ -136,6 +138,61 @@ struct DashboardView: View {
                     Text("Details →").font(Theme.Fonts.bodyMedium)
                 }).buttonStyle(.plain).foregroundColor(Theme.Colors.accent)
             }.buttonStyle(.bordered).disabled(carButtonsDisabled)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Theme.Colors.secondaryBackground)
+        .cornerRadius(12)
+    }
+
+    // MARK: - Scooter
+    private var scooterCard: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Image(systemName: "scooter")
+                    .foregroundColor(Theme.Colors.accent)
+                Text("GT3 Pro")
+                    .font(Theme.Fonts.headerLarge())
+                    .foregroundColor(Theme.Colors.textPrimary)
+            }
+            VStack(alignment: .leading, spacing: 8) {
+                if let timestamp = scooter.summary.timestamp {
+                    Text("Updated \(relativeTimeString(from: timestamp))")
+                        .font(Theme.Fonts.caption)
+                        .foregroundColor(Theme.Colors.textSecondary)
+                }
+                HStack(spacing: 16) {
+                    Label(scooter.formattedOdometer, systemImage: "gauge.with.dots.needle.67percent")
+                        .foregroundColor(Theme.Colors.textPrimary)
+                    if let cycles = scooter.summary.batteryCycles {
+                        Label("\(cycles) cycles", systemImage: "battery.100percent.circle")
+                            .foregroundColor(Theme.Colors.textPrimary)
+                    }
+                }.font(Theme.Fonts.bodyMedium)
+                if let lastRide = scooter.summary.lastRide {
+                    HStack(spacing: 16) {
+                        Label(
+                            scooter.formattedLastRideDistance,
+                            systemImage: "point.topleft.down.to.point.bottomright.curvepath"
+                        )
+                        if let maxSpeed = lastRide.maxSpeed {
+                            Label(String(format: "%.1f km/h", maxSpeed), systemImage: "speedometer")
+                        }
+                        if let battUsed = lastRide.batteryUsed {
+                            Label("-\(battUsed)%", systemImage: "battery.75percent")
+                        }
+                    }
+                    .font(Theme.Fonts.bodyMedium)
+                    .foregroundColor(Theme.Colors.textPrimary)
+                }
+            }
+            Divider()
+            HStack {
+                Button(action: { onNavigate(.scooter) }, label: {
+                    Text("Details →").font(Theme.Fonts.bodyMedium)
+                }).buttonStyle(.plain).foregroundColor(Theme.Colors.accent)
+                Spacer()
+            }
         }
         .padding()
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -381,6 +438,7 @@ extension DashboardView {
         robots: MockData.createRobots(),
         battery: MockData.createBattery(),
         car: MockData.createCar(),
+        scooter: Scooter(),
         apiResponse: MockData.createApi(),
         locationManager: LocationManager(),
         radarService: RadarService(),

--- a/macOS/DashboardView.swift
+++ b/macOS/DashboardView.swift
@@ -161,6 +161,17 @@ struct DashboardView: View {
                         .font(Theme.Fonts.caption)
                         .foregroundColor(Theme.Colors.textSecondary)
                 }
+                if let battery = scooter.summary.battery {
+                    HStack(spacing: 4) {
+                        Text("Battery: \(battery)%")
+                        if let range = scooter.summary.estimatedRange {
+                            Text("·")
+                            Text(String(format: "%.0f km", range))
+                        }
+                    }
+                    .font(Theme.Fonts.bodyLarge)
+                    .foregroundColor(Theme.Colors.textPrimary)
+                }
                 HStack(spacing: 16) {
                     Label(scooter.formattedOdometer, systemImage: "gauge.with.dots.needle.67percent")
                         .foregroundColor(Theme.Colors.textPrimary)

--- a/macOS/MacApp.swift
+++ b/macOS/MacApp.swift
@@ -339,6 +339,7 @@ struct MacApp: App {
     @State private var robots: Robots?
     @State private var car: Car?
     @State private var chat = Chat()
+    @State private var scooter: Scooter?
     @AppStorage("showMenuBarExtra") private var showMenuBar = true
 
     let timer = Timer.publish(every: 5, on: .main, in: .common).autoconnect()
@@ -384,10 +385,12 @@ struct MacApp: App {
                     .keyboardShortcut("4", modifiers: .command)
                 Button("Car") { postNavigation("Car") }
                     .keyboardShortcut("5", modifiers: .command)
-                Button("Robots") { postNavigation("Robots") }
+                Button("Scooter") { postNavigation("Scooter") }
                     .keyboardShortcut("6", modifiers: .command)
-                Button("Assistant") { postNavigation("Assistant") }
+                Button("Robots") { postNavigation("Robots") }
                     .keyboardShortcut("7", modifiers: .command)
+                Button("Assistant") { postNavigation("Assistant") }
+                    .keyboardShortcut("8", modifiers: .command)
 
                 Divider()
 
@@ -440,7 +443,7 @@ struct MacApp: App {
                 ) { object in
                     handleDataUpdated(object)
                 }
-        } else if let hconn, let miele, let robots, let car {
+        } else if let hconn, let miele, let robots, let car, let scooter {
             ContentView(
                 fluxHausConsts: fluxHausConsts,
                 hconn: hconn,
@@ -448,6 +451,7 @@ struct MacApp: App {
                 robots: robots,
                 battery: battery,
                 car: car,
+                scooter: scooter,
                 apiResponse: apiResponse,
                 chat: chat
             )
@@ -473,6 +477,7 @@ struct MacApp: App {
                     hconn.setApiResponse(apiResponse: self.apiResponse)
                     miele.setApiResponse(apiResponse: self.apiResponse)
                     car.setApiResponse(apiResponse: self.apiResponse)
+                    scooter.setApiResponse(apiResponse: self.apiResponse)
                 }
             }
             .onReceive(timer) { _ in
@@ -543,6 +548,8 @@ struct MacApp: App {
             self.robots?.apiResponse = self.apiResponse
             self.car = Car()
             self.car?.setApiResponse(apiResponse: self.apiResponse)
+            self.scooter = Scooter()
+            self.scooter?.setApiResponse(apiResponse: self.apiResponse)
             self.hconn = HomeConnect(apiResponse: self.apiResponse)
         }
     }


### PR DESCRIPTION
## Summary

Adds GT3 Pro scooter as a new device in the FluxHaus app, following the same patterns as the existing Car integration.

### New Files
- `Shared/Scooter.swift` — `@Observable` model class with formatted properties for odometer, ride time, distance, and date
- `Shared/ScooterDetailView.swift` — Detail view with Status and Last Ride sections using Theme styles

### Modified Files
- `Shared/LoginStucts.swift` — Added `ScooterLastRide`, `ScooterSummary` structs and `scooter` field to `LoginResponse`
- `iOS/ContentView.swift` — Added scooter property, tab, and keyboard shortcut
- `iOS/FluxHausApp.swift` — Added scooter instance, wiring, and Navigate menu entry
- `macOS/ContentView.swift` — Added `.scooter` to `SidebarItem`, detail view routing, keyboard shortcut
- `macOS/DashboardView.swift` — Added scooter property and dashboard card
- `macOS/MacApp.swift` — Added scooter instance and wiring
- `VisionOS/ContentView.swift` & `VisionOSApp.swift` — Same scooter integration
- `Tests macOS/Tests_macOS_ViewTests.swift` — Updated SidebarItem tests

### Depends On
- djensenius/FluxHaus-Server PR for the `scooter` field in the API response