### PR TITLE
Add scooter to home page and flip scooter icon direction

### DIFF
--- a/Shared/AppliancesView.swift
+++ b/Shared/AppliancesView.swift
@@ -34,6 +34,7 @@ struct Appliances: View {
         (name: "BroomBot", index: 0),
         (name: "MopBot", index: 0),
         (name: "Car", index: 0),
+        (name: "Scooter", index: 0),
         (name: "Battery", index: 0)
     ]
 
@@ -50,17 +51,18 @@ struct Appliances: View {
                                     HStack {
                                         VStack(alignment: .leading) {
                                             HStack {
-                                                Text(
-                                                    getIcon(
-                                                        type: theAppliances[app].name,
-                                                        index: theAppliances[app].index
-                                                    )
+                                                getIcon(
+                                                    type: theAppliances[app].name,
+                                                    index: theAppliances[app].index
                                                 )
                                                 .font(Theme.Fonts.headerLarge())
                                                 .foregroundColor(getIconColor(
                                                     type: theAppliances[app].name,
                                                     index: theAppliances[app].index
                                                 ))
+                                                .scaleEffect(
+                                                    x: theAppliances[app].name == "Scooter" ? -1 : 1
+                                                )
                                                 .padding(.leading)
                                                 Text(
                                                     getApplianceName(

--- a/Shared/AppliancesView.swift
+++ b/Shared/AppliancesView.swift
@@ -60,9 +60,6 @@ struct Appliances: View {
                                                     type: theAppliances[app].name,
                                                     index: theAppliances[app].index
                                                 ))
-                                                .scaleEffect(
-                                                    x: theAppliances[app].name == "Scooter" ? -1 : 1
-                                                )
                                                 .padding(.leading)
                                                 Text(
                                                     getApplianceName(

--- a/Shared/AppliancesViewExtensions.swift
+++ b/Shared/AppliancesViewExtensions.swift
@@ -71,34 +71,34 @@ extension Appliances {
         return Theme.Colors.textSecondary
     }
 
-    func getIcon(type: String, index: Int) -> Image {
-        var tAppliance: [Appliance]
-        if type == "Miele" {
-            tAppliance = miele.appliances
-        } else if type == "MopBot" {
-            return Image(systemName: "humidifier.and.droplets")
-        } else if type == "BroomBot" {
-            return Image(systemName: "fan")
-        } else if type == "Battery" {
-            return getDeviceIcon(battery: battery)
-        } else if type == "Car" {
-            return Image(systemName: "car")
-        } else if type == "Scooter" {
-            return Image(systemName: "scooter")
-        } else {
-            tAppliance = hconn.appliances
+    @ViewBuilder
+    func getIcon(type: String, index: Int) -> some View {
+        switch type {
+        case "MopBot":
+            Image(systemName: "humidifier.and.droplets")
+        case "BroomBot":
+            Image(systemName: "fan")
+        case "Battery":
+            getDeviceIcon(battery: battery)
+        case "Car":
+            Image(systemName: "car")
+        case "Scooter":
+            Image(systemName: "scooter")
+                .scaleEffect(x: -1)
+        case "Miele":
+            applianceIcon(for: miele.appliances, index: index)
+        default:
+            applianceIcon(for: hconn.appliances, index: index)
         }
+    }
 
-        if tAppliance.count > index {
-            var emoji = Image(systemName: "dryer")
-            if tAppliance[index].name == "Washing machine" {
-                emoji = Image(systemName: "washer")
-            } else if tAppliance[index].name == "Dishwasher" {
-                emoji = Image(systemName: "dishwasher")
-            }
-            return emoji
+    private func applianceIcon(for appliances: [Appliance], index: Int) -> Image {
+        guard appliances.count > index else { return Image(systemName: "network") }
+        switch appliances[index].name {
+        case "Washing machine": return Image(systemName: "washer")
+        case "Dishwasher": return Image(systemName: "dishwasher")
+        default: return Image(systemName: "dryer")
         }
-        return Image(systemName: "network")
     }
 
     func getApplianceName(type: String, index: Int) -> String {

--- a/Shared/ScooterDetailView.swift
+++ b/Shared/ScooterDetailView.swift
@@ -15,6 +15,7 @@ struct ScooterDetailView: View {
                     #if !os(macOS)
                     HStack {
                         Image(systemName: "scooter")
+                            .scaleEffect(x: -1)
                         Text("GT3 Pro")
                     }
                     .font(Theme.Fonts.headerXL())

--- a/Tests iOS/MockDataUITests.swift
+++ b/Tests iOS/MockDataUITests.swift
@@ -299,13 +299,14 @@ struct ApplianceDisplayTests {
         await drainMainQueue()
 
         let view = mockAppliances(hconn: hconn, miele: miele, robots: robots, car: car)
-        #expect(view.originalAppliances.count == 7)
+        #expect(view.originalAppliances.count == 8)
         let names = view.originalAppliances.map { $0.name }
         #expect(names.contains("HomeConnect"))
         #expect(names.contains("Miele"))
         #expect(names.contains("BroomBot"))
         #expect(names.contains("MopBot"))
         #expect(names.contains("Car"))
+        #expect(names.contains("Scooter"))
         #expect(names.contains("Battery"))
     }
 

--- a/VisionOS/ContentView.swift
+++ b/VisionOS/ContentView.swift
@@ -43,7 +43,14 @@ struct ContentView: View {
                 .tabItem { Label("Car", systemImage: "car.fill") }
                 .tag("Car")
             scooterTab
-                .tabItem { Label("Scooter", systemImage: "scooter") }
+                .tabItem {
+                    Label {
+                        Text("Scooter")
+                    } icon: {
+                        Image(systemName: "scooter")
+                            .scaleEffect(x: -1)
+                    }
+                }
                 .tag("Scooter")
             RobotsListView(robots: robots)
                 .tabItem { Label("Robots", systemImage: "fan.fill") }

--- a/iOS/ContentView.swift
+++ b/iOS/ContentView.swift
@@ -44,8 +44,15 @@ struct ContentView: View {
                 carTab
             }
             .customizationID("car")
-            Tab("Scooter", systemImage: "scooter", value: "scooter") {
+            Tab(value: "scooter") {
                 scooterTab
+            } label: {
+                Label {
+                    Text("Scooter")
+                } icon: {
+                    Image(systemName: "scooter")
+                        .scaleEffect(x: -1)
+                }
             }
             .customizationID("scooter")
             TabSection {

--- a/macOS/DashboardView.swift
+++ b/macOS/DashboardView.swift
@@ -150,6 +150,7 @@ struct DashboardView: View {
         VStack(alignment: .leading, spacing: 12) {
             HStack {
                 Image(systemName: "scooter")
+                    .scaleEffect(x: -1)
                     .foregroundColor(Theme.Colors.accent)
                 Text("GT3 Pro")
                     .font(Theme.Fonts.headerLarge())


### PR DESCRIPTION
## Changes

- **Added scooter to the home page**: Added a `Scooter` entry to the `originalAppliances` array in `AppliancesView.swift`, so the scooter now appears on the home tab's appliance list right below the car.

- **Flipped scooter icon direction**: Applied `.scaleEffect(x: -1)` to the scooter SF Symbol icon across all views where it appears:
  - Home page appliance grid (`AppliancesView.swift`)
  - Scooter detail view (`ScooterDetailView.swift`)
  - macOS dashboard (`DashboardView.swift`)
  - iOS tab bar (`iOS/ContentView.swift`)
  - VisionOS tab bar (`VisionOS/ContentView.swift`)