### PR TITLE
Fix duplicate Live Activities: serialize reconcile, await ends, dedup tokens

### DIFF
--- a/FluxHaus.xcodeproj/project.pbxproj
+++ b/FluxHaus.xcodeproj/project.pbxproj
@@ -1348,7 +1348,7 @@ MP0002000000000000000004 /* MarkdownParser.swift in Sources */,
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.6;
+				MARKETING_VERSION = 1.8.7;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.davidjensenius.FluxHaus.Tests-macOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
@@ -1414,7 +1414,7 @@ MP0002000000000000000004 /* MarkdownParser.swift in Sources */,
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.6;
+				MARKETING_VERSION = 1.8.7;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -1475,7 +1475,7 @@ MP0002000000000000000004 /* MarkdownParser.swift in Sources */,
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.6;
+				MARKETING_VERSION = 1.8.7;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -1503,7 +1503,7 @@ MP0002000000000000000004 /* MarkdownParser.swift in Sources */,
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.6;
+				MARKETING_VERSION = 1.8.7;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus;
 				PRODUCT_NAME = FluxHaus;
 				SDKROOT = iphoneos;
@@ -1536,7 +1536,7 @@ MP0002000000000000000004 /* MarkdownParser.swift in Sources */,
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.6;
+				MARKETING_VERSION = 1.8.7;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus;
 				PRODUCT_NAME = FluxHaus;
 				SDKROOT = iphoneos;
@@ -1565,7 +1565,7 @@ MP0002000000000000000004 /* MarkdownParser.swift in Sources */,
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.6;
+				MARKETING_VERSION = 1.8.7;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.davidjensenius.Tests-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1592,7 +1592,7 @@ MP0002000000000000000004 /* MarkdownParser.swift in Sources */,
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.6;
+				MARKETING_VERSION = 1.8.7;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.davidjensenius.Tests-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1631,7 +1631,7 @@ MP0002000000000000000004 /* MarkdownParser.swift in Sources */,
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.8.6;
+				MARKETING_VERSION = 1.8.7;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus.FluxWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1670,7 +1670,7 @@ MP0002000000000000000004 /* MarkdownParser.swift in Sources */,
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.8.6;
+				MARKETING_VERSION = 1.8.7;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus.FluxWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1707,7 +1707,7 @@ MP0002000000000000000004 /* MarkdownParser.swift in Sources */,
 					"@executable_path/Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.8.6;
+				MARKETING_VERSION = 1.8.7;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus;
 				PRODUCT_MODULE_NAME = FluxHaus;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1745,7 +1745,7 @@ MP0002000000000000000004 /* MarkdownParser.swift in Sources */,
 					"@executable_path/Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.8.6;
+				MARKETING_VERSION = 1.8.7;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus;
 				PRODUCT_MODULE_NAME = FluxHaus;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1771,7 +1771,7 @@ MP0002000000000000000004 /* MarkdownParser.swift in Sources */,
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.8.6;
+				MARKETING_VERSION = 1.8.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jensenius.fluxhaus.VisionOSTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = xros;
@@ -1797,7 +1797,7 @@ MP0002000000000000000004 /* MarkdownParser.swift in Sources */,
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.8.6;
+				MARKETING_VERSION = 1.8.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jensenius.fluxhaus.VisionOSTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = xros;
@@ -1844,7 +1844,7 @@ MP0002000000000000000004 /* MarkdownParser.swift in Sources */,
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.6;
+				MARKETING_VERSION = 1.8.7;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus;
 				PRODUCT_NAME = FluxHaus;
 				SDKROOT = macosx;
@@ -1884,7 +1884,7 @@ MP0002000000000000000004 /* MarkdownParser.swift in Sources */,
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.6;
+				MARKETING_VERSION = 1.8.7;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus;
 				PRODUCT_NAME = FluxHaus;
 				SDKROOT = macosx;
@@ -1900,7 +1900,7 @@ MP0002000000000000000004 /* MarkdownParser.swift in Sources */,
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.6;
+				MARKETING_VERSION = 1.8.7;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.davidjensenius.FluxHaus.Tests-macOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;

--- a/Shared/AuthManager.swift
+++ b/Shared/AuthManager.swift
@@ -14,6 +14,10 @@ import os
 import AppKit
 #endif
 
+extension Notification.Name {
+    static let authDidSignOut = Notification.Name("authDidSignOut")
+}
+
 private let logger = Logger(subsystem: "io.fluxhaus.FluxHaus", category: "AuthManager")
 
 // Provides a presentation anchor for ASWebAuthenticationSession.
@@ -287,9 +291,7 @@ class AuthManager: ObservableObject, @unchecked Sendable {
         var whereWeAre = WhereWeAre()
         whereWeAre.deleteKeyChainPasword()
         authState = .signedOut
-        #if os(iOS)
-        LiveActivityManager.shared.resetTokenRegistrationState()
-        #endif
+        NotificationCenter.default.post(name: .authDidSignOut, object: nil)
     }
 
     // MARK: - Token Management

--- a/Shared/AuthManager.swift
+++ b/Shared/AuthManager.swift
@@ -287,6 +287,9 @@ class AuthManager: ObservableObject, @unchecked Sendable {
         var whereWeAre = WhereWeAre()
         whereWeAre.deleteKeyChainPasword()
         authState = .signedOut
+        #if os(iOS)
+        LiveActivityManager.shared.resetTokenRegistrationState()
+        #endif
     }
 
     // MARK: - Token Management

--- a/Shared/LiveActivityManager.swift
+++ b/Shared/LiveActivityManager.swift
@@ -41,6 +41,12 @@ class LiveActivityManager {
     private var channelIds: [String: String] = [:]
     private var pushToStartTask: Task<Void, Never>?
 
+    /// Reentrancy guard for reconcile — prevents concurrent calls from both creating activities
+    private var isReconciling = false
+
+    /// Last registered push-to-start token — skip duplicates like GT3
+    private var lastRegisteredPushToStartToken: String?
+
     /// User's subscription preferences (which device types to show)
     var subscribedDeviceTypes: Set<String> = Set(["Dishwasher", "Washer", "Dryer", "BroomBot", "MopBot"]) {
         didSet { saveSubscriptionPreferences() }
@@ -104,6 +110,11 @@ class LiveActivityManager {
             pushToStartTask = Task {
                 for await tokenData in Activity<FluxWidgetMultiAttributes>.pushToStartTokenUpdates {
                     let token = tokenData.map { String(format: "%02x", $0) }.joined()
+                    // Skip duplicate registrations
+                    guard token != lastRegisteredPushToStartToken else {
+                        logger.debug("Push-to-start token unchanged — skipping registration")
+                        continue
+                    }
                     logger.info("Push-to-start token (multi): \(token.prefix(8))...")
                     pendingPushToStartToken = token
                     await registerPushToStartTokenWhenReady()
@@ -123,6 +134,7 @@ class LiveActivityManager {
             return
         }
         await registerDeviceToken(token: token)
+        lastRegisteredPushToStartToken = token
         pendingPushToStartToken = nil
     }
 
@@ -224,6 +236,14 @@ class LiveActivityManager {
             return
         }
 
+        // Serialize: if a reconcile is already in progress, skip this one
+        guard !isReconciling else {
+            logger.debug("reconcile: already in progress — skipping")
+            return
+        }
+        isReconciling = true
+        defer { isReconciling = false }
+
         await cleanupAndAdoptActivities()
 
         // Filter by subscription preferences
@@ -241,16 +261,17 @@ class LiveActivityManager {
         } else {
             // Start a new consolidated activity (only if none exists)
             consolidatedActivity = nil
-            startConsolidatedActivity(devices: runningDevices)
+            await startConsolidatedActivity(devices: runningDevices)
         }
     }
 
-    private func startConsolidatedActivity(devices: [WidgetDevice]) {
-        // Safety: end any orphaned activities before starting a new one
+    private func startConsolidatedActivity(devices: [WidgetDevice]) async {
+        // End any orphaned activities before starting a new one (await to avoid race)
         for activity in Activity<FluxWidgetMultiAttributes>.activities
         where activity.activityState == .active || activity.activityState == .stale {
             nonisolated(unsafe) let activityRef = activity
-            Task { await activityRef.end(nil, dismissalPolicy: .immediate) }
+            await activityRef.end(nil, dismissalPolicy: .immediate)
+            logger.info("Ended orphaned activity before starting new one")
         }
 
         let attributes = FluxWidgetMultiAttributes(name: "Appliances")

--- a/Shared/LiveActivityManager.swift
+++ b/Shared/LiveActivityManager.swift
@@ -63,10 +63,20 @@ class LiveActivityManager {
     private init() {
         loadSubscriptionPreferences()
         observePushToStartToken()
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleAuthSignOut),
+            name: .authDidSignOut,
+            object: nil
+        )
         Task {
             await restoreExistingActivities()
             await fetchChannelIds()
         }
+    }
+
+    @objc private func handleAuthSignOut() {
+        resetTokenRegistrationState()
     }
 
     /// Re-adopt activities that iOS kept alive while the app was killed.

--- a/Shared/LiveActivityManager.swift
+++ b/Shared/LiveActivityManager.swift
@@ -43,9 +43,17 @@ class LiveActivityManager {
 
     /// Reentrancy guard for reconcile — prevents concurrent calls from both creating activities
     private var isReconciling = false
+    /// Pending devices for coalesced reconcile — if a reconcile is skipped, re-run with latest data
+    private var pendingReconcileDevices: [WidgetDevice]?
 
     /// Last registered push-to-start token — skip duplicates like GT3
     private var lastRegisteredPushToStartToken: String?
+
+    /// Reset dedup state when auth changes (e.g. sign-out/sign-in)
+    func resetTokenRegistrationState() {
+        lastRegisteredPushToStartToken = nil
+        pendingPushToStartToken = nil
+    }
 
     /// User's subscription preferences (which device types to show)
     var subscribedDeviceTypes: Set<String> = Set(["Dishwasher", "Washer", "Dryer", "BroomBot", "MopBot"]) {
@@ -133,9 +141,11 @@ class LiveActivityManager {
             logger.info("Auth not ready — deferring push-to-start token registration")
             return
         }
-        await registerDeviceToken(token: token)
-        lastRegisteredPushToStartToken = token
-        pendingPushToStartToken = nil
+        let success = await registerDeviceToken(token: token)
+        if success {
+            lastRegisteredPushToStartToken = token
+            pendingPushToStartToken = nil
+        }
     }
 
     /// Called when auth becomes available to retry any pending registration.
@@ -236,14 +246,26 @@ class LiveActivityManager {
             return
         }
 
-        // Serialize: if a reconcile is already in progress, skip this one
+        // Coalesce: if a reconcile is in progress, store the latest devices and re-run after
         guard !isReconciling else {
-            logger.debug("reconcile: already in progress — skipping")
+            logger.debug("reconcile: already in progress — coalescing")
+            pendingReconcileDevices = devices
             return
         }
         isReconciling = true
-        defer { isReconciling = false }
 
+        await performReconcile(devices: devices)
+
+        // If another reconcile was requested during ours, run it with the latest data
+        while let pending = pendingReconcileDevices {
+            pendingReconcileDevices = nil
+            await performReconcile(devices: pending)
+        }
+
+        isReconciling = false
+    }
+
+    private func performReconcile(devices: [WidgetDevice]) async {
         await cleanupAndAdoptActivities()
 
         // Filter by subscription preferences
@@ -382,8 +404,8 @@ class LiveActivityManager {
         }
     }
 
-    private func registerDeviceToken(token: String) async {
-        await postToServer(
+    private func registerDeviceToken(token: String) async -> Bool {
+        return await postToServer(
             path: "/push-tokens/device",
             body: [
                 "pushToStartToken": token,
@@ -392,17 +414,18 @@ class LiveActivityManager {
         )
     }
 
-    private func postToServer(path: String, body: [String: String]) async {
+    @discardableResult
+    private func postToServer(path: String, body: [String: String]) async -> Bool {
         var components = URLComponents()
         components.scheme = "https"
         components.host = "api.fluxhaus.io"
         components.path = path
 
-        guard let url = components.url else { return }
+        guard let url = components.url else { return false }
 
         guard let authHeader = AuthManager.shared.authorizationHeader() else {
             logger.warning("No auth header available — skipping POST to \(path)")
-            return
+            return false
         }
 
         let csrfToken = await fetchCsrfToken()
@@ -423,6 +446,7 @@ class LiveActivityManager {
             if let httpResponse = response as? HTTPURLResponse {
                 if httpResponse.statusCode == 200 {
                     logger.info("Registered token at \(path)")
+                    return true
                 } else {
                     logger.error("Server returned \(httpResponse.statusCode) for \(path)")
                 }
@@ -430,6 +454,7 @@ class LiveActivityManager {
         } catch {
             logger.error("Failed to register token at \(path): \(error)")
         }
+        return false
     }
 }
 #endif


### PR DESCRIPTION
## Problem
Users see duplicate and uncombined Live Activities.

## Root Causes (client-side)
1. **Fire-and-forget orphan cleanup** — old activities not fully ended before new one created
2. **Concurrent `reconcile()` calls** — silent push + push-to-start arriving simultaneously
3. **Duplicate push-to-start token registration** — unnecessary server calls

## Fixes
- Await orphan activity endings instead of fire-and-forget `Task{}`
- Serialize `reconcile()` with a reentrancy guard
- Track `lastRegisteredPushToStartToken` to skip duplicates (matches GT3 pattern)

## Companion PR
FluxHaus Server: djensenius/FluxHaus-Server#297

## Testing
- Swift compiles and lint passes