### PR TITLE
Fix auth, window management, and widget build issues

### DIFF
--- a/FluxWidget/FluxWidgetBundle.swift
+++ b/FluxWidget/FluxWidgetBundle.swift
@@ -13,7 +13,7 @@ struct FluxWidgetBundle: WidgetBundle {
     var body: some Widget {
         FluxWidget()
         FluxWidgetOtherSmall()
-        #if os(iOS)
+        #if os(iOS) && !targetEnvironment(macCatalyst)
         FluxWidgetMultiLiveActivity()
         FluxWidgetLiveActivity()
         #endif

--- a/FluxWidget/FluxWidgetLiveActivity.swift
+++ b/FluxWidget/FluxWidgetLiveActivity.swift
@@ -5,11 +5,13 @@
 //  Created by David Jensenius on 2024-08-01.
 //
 
-#if os(iOS)
+#if os(iOS) && !targetEnvironment(macCatalyst)
 import ActivityKit
 import WidgetKit
+#endif
 import SwiftUI
 
+#if os(iOS) && !targetEnvironment(macCatalyst)
 struct FluxWidgetAttributes: ActivityAttributes {
     public struct ContentState: Codable, Hashable {
         var device: WidgetDevice
@@ -332,6 +334,7 @@ struct FluxWidgetMultiLiveActivity: Widget {
         }
     }
 }
+#endif
 
 // MARK: - Helpers
 
@@ -370,6 +373,7 @@ func batteryIcon(level: Int) -> String {
 
 // MARK: - Preview Data
 
+#if os(iOS) && !targetEnvironment(macCatalyst)
 extension FluxWidgetMultiAttributes {
     static var preview: FluxWidgetMultiAttributes {
         FluxWidgetMultiAttributes(name: "Appliances")

--- a/FluxWidget/FluxWidgetLiveActivityLegacy.swift
+++ b/FluxWidget/FluxWidgetLiveActivityLegacy.swift
@@ -6,7 +6,7 @@
 //  with existing push-to-start tokens. New installs use FluxWidgetMultiLiveActivity.
 //
 
-#if os(iOS)
+#if os(iOS) && !targetEnvironment(macCatalyst)
 import ActivityKit
 import WidgetKit
 import SwiftUI
@@ -35,9 +35,10 @@ struct FluxWidgetLiveActivity: Widget {
             .activityBackgroundTint(Color(.systemBackground).opacity(0.8))
         } dynamicIsland: { context in
             DynamicIsland {
-                DynamicIslandExpandedRegion(.leading) { Text("") }
-                DynamicIslandExpandedRegion(.trailing) { Text("") }
-                DynamicIslandExpandedRegion(.bottom) { Text("") }
+                DynamicIslandExpandedRegion(.bottom) {
+                    Text(context.state.device.name)
+                        .font(.headline)
+                }
             } compactLeading: {
                 Image(systemName: context.state.device.icon)
                     .foregroundStyle(tintColor(for: context.state.device.name))

--- a/FluxWidget/FluxWidgetWatchViews.swift
+++ b/FluxWidget/FluxWidgetWatchViews.swift
@@ -225,7 +225,7 @@ struct PhoneMultiDeviceView: View {
     }
 }
 
-@ViewBuilder
+@MainActor @ViewBuilder
 func phoneDeviceProgressBar(device: WidgetDevice) -> some View {
     if isRobot(device.name) {
         if let battery = device.battery {

--- a/FluxWidget/FluxWidgetWatchViews.swift
+++ b/FluxWidget/FluxWidgetWatchViews.swift
@@ -5,7 +5,7 @@
 //  Watch-specific Live Activity views for the Smart Stack.
 //
 
-#if os(iOS)
+#if os(iOS) && !targetEnvironment(macCatalyst)
 import SwiftUI
 import WidgetKit
 

--- a/Shared/AuthManager.swift
+++ b/Shared/AuthManager.swift
@@ -212,6 +212,11 @@ class AuthManager: ObservableObject, @unchecked Sendable {
     // MARK: - OIDC Sign In
     @MainActor func signInWithOIDC() async throws {
         isCompletingOIDCLogin = true
+        defer {
+            if !isSignedIn {
+                isCompletingOIDCLogin = false
+            }
+        }
         let codeVerifier = generateCodeVerifier()
         let codeChallenge = generateCodeChallenge(from: codeVerifier)
         let state = generateRandomString()

--- a/Shared/AuthManager.swift
+++ b/Shared/AuthManager.swift
@@ -147,6 +147,10 @@ class AuthManager: ObservableObject, @unchecked Sendable {
 
     @Published var authState: AuthState = .unknown
 
+    /// True while an OIDC sign-in is completing (exchange → first API call).
+    /// Used to suppress duplicate queryFlux triggered by scenePhase changes.
+    @Published var isCompletingOIDCLogin = false
+
     // Keep strong references to prevent deallocation during auth
     private var currentAuthSession: ASWebAuthenticationSession?
     private var anchorProvider: AuthSessionAnchorProvider?
@@ -207,6 +211,7 @@ class AuthManager: ObservableObject, @unchecked Sendable {
 
     // MARK: - OIDC Sign In
     @MainActor func signInWithOIDC() async throws {
+        isCompletingOIDCLogin = true
         let codeVerifier = generateCodeVerifier()
         let codeChallenge = generateCodeChallenge(from: codeVerifier)
         let state = generateRandomString()
@@ -285,6 +290,7 @@ class AuthManager: ObservableObject, @unchecked Sendable {
     // MARK: - Sign Out
     @MainActor func signOut() {
         logger.warning("signOut() called — clearing all tokens and credentials")
+        isCompletingOIDCLogin = false
         deleteKeychainItem(account: "oidc_access_token")
         deleteKeychainItem(account: "oidc_refresh_token")
         deleteKeychainItem(account: "oidc_token_expiry")

--- a/Shared/LiveActivityManager.swift
+++ b/Shared/LiveActivityManager.swift
@@ -5,7 +5,7 @@
 //  Created by David Jensenius on 2025-03-09.
 //
 
-#if os(iOS)
+#if os(iOS) && !targetEnvironment(macCatalyst)
 import ActivityKit
 import Foundation
 import UIKit

--- a/Shared/NotificationSettingsView.swift
+++ b/Shared/NotificationSettingsView.swift
@@ -81,11 +81,6 @@ struct SettingsView: View {
             Section {
                 Button(role: .destructive) {
                     AuthManager.shared.signOut()
-                    NotificationCenter.default.post(
-                        name: Notification.Name.logout,
-                        object: nil,
-                        userInfo: ["logout": true]
-                    )
                 } label: {
                     Label("Sign Out", systemImage: "rectangle.portrait.and.arrow.right")
                 }

--- a/Shared/NotificationSettingsView.swift
+++ b/Shared/NotificationSettingsView.swift
@@ -5,7 +5,7 @@
 //  Created by David Jensenius on 2026-03-22.
 //
 
-#if os(iOS)
+#if os(iOS) && !targetEnvironment(macCatalyst)
 import SwiftUI
 import ActivityKit
 
@@ -72,11 +72,17 @@ struct NotificationSettingsSection: View {
         )
     }
 }
+#endif
+
+#if os(iOS)
+import SwiftUI
 
 struct SettingsView: View {
     var body: some View {
         List {
+            #if !targetEnvironment(macCatalyst)
             NotificationSettingsSection()
+            #endif
 
             Section {
                 Button(role: .destructive) {

--- a/Shared/QueryFlux.swift
+++ b/Shared/QueryFlux.swift
@@ -161,6 +161,10 @@ private func handleQueryFluxResponse(data: Data?, error: Error?, password: Strin
             let response = try JSONDecoder().decode(LoginResponse.self, from: data)
             DispatchQueue.main.async {
                 AuthManager.shared.isCompletingOIDCLogin = false
+                guard AuthManager.shared.isSignedIn else {
+                    logger.debug("Ignoring late queryFlux success after sign-out")
+                    return
+                }
                 NotificationCenter.default.post(
                     name: Notification.Name.loginsUpdated,
                     object: response,
@@ -204,17 +208,12 @@ private func handleQueryFluxResponse(data: Data?, error: Error?, password: Strin
 }
 
 func getFlux(password: String) async throws -> LoginResponse? {
-    let scheme: String = "https"
-    let host: String = "api.fluxhaus.io"
-    let path = "/"
-
     var components = URLComponents()
-    components.scheme = scheme
-    components.host = host
-    components.path = path
+    components.scheme = "https"
+    components.host = "api.fluxhaus.io"
+    components.path = "/"
 
     let url = components.url!
-
     var request = URLRequest(url: url)
     if let authHeader = AuthManager.shared.authorizationHeader() {
         request.setValue(authHeader, forHTTPHeaderField: "Authorization")

--- a/Shared/QueryFlux.swift
+++ b/Shared/QueryFlux.swift
@@ -63,34 +63,29 @@ class BasicAuthDelegate: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
     }
 }
 
-func queryFlux(password: String) {
-    let scheme: String = "https"
-    let host: String = "api.fluxhaus.io"
-    let path = "/"
-
+private func buildFluxAPIRequest(password: String) -> URLRequest? {
     var components = URLComponents()
-    components.scheme = scheme
-    components.host = host
-    components.path = path
-
-    guard let url = components.url else {
-        return
-    }
+    components.scheme = "https"
+    components.host = "api.fluxhaus.io"
+    components.path = "/"
+    guard let url = components.url else { return nil }
 
     var request = URLRequest(url: url)
     request.httpMethod = "get"
-
     request.addValue("application/json", forHTTPHeaderField: "Content-Type")
     request.addValue("application/json", forHTTPHeaderField: "Accept")
-
     if let authHeader = AuthManager.shared.authorizationHeader() {
         request.setValue(authHeader, forHTTPHeaderField: "Authorization")
     } else {
-        // Fallback for demo login
-        let credentialData = Data("demo:\(password)".utf8)
-        let base64Credential = credentialData.base64EncodedString()
-        request.setValue("Basic \(base64Credential)", forHTTPHeaderField: "Authorization")
+        let base64 = Data("demo:\(password)".utf8).base64EncodedString()
+        request.setValue("Basic \(base64)", forHTTPHeaderField: "Authorization")
     }
+    return request
+}
+
+func queryFlux(password: String) {
+    guard let request = buildFluxAPIRequest(password: password) else { return }
+
     let session = URLSession(configuration: .default, delegate: nil, delegateQueue: nil)
     let task = session.dataTask(with: request) { data, response, error in
         let httpResponse = response as? HTTPURLResponse
@@ -98,30 +93,13 @@ func queryFlux(password: String) {
             handleUnauthorized(password: password)
             return
         }
-        authRetryCount = 0
         handleQueryFluxResponse(data: data, error: error, password: password)
     }
     task.resume()
 }
 
-private nonisolated(unsafe) var authRetryCount = 0
-
 private func handleUnauthorized(password: String) {
     if AuthManager.shared.getAccessToken() != nil {
-        guard authRetryCount < 1 else {
-            authRetryCount = 0
-            logger.error("handleUnauthorized: still 401 after refresh — signing out")
-            DispatchQueue.main.async {
-                AuthManager.shared.signOut()
-                NotificationCenter.default.post(
-                    name: Notification.Name.loginsUpdated,
-                    object: nil,
-                    userInfo: ["keysFailed": true]
-                )
-            }
-            return
-        }
-        authRetryCount += 1
         logger.debug("handleUnauthorized: 401 with OIDC token, requesting refresh")
         Task { @MainActor in
             let oldToken = AuthManager.shared.getAccessToken()?.suffix(8) ?? "nil"
@@ -129,9 +107,8 @@ private func handleUnauthorized(password: String) {
             if refreshed {
                 let newToken = AuthManager.shared.getAccessToken()?.suffix(8) ?? "nil"
                 logger.debug("handleUnauthorized: refresh succeeded (…\(oldToken) → …\(newToken)), retrying")
-                queryFlux(password: password)
+                retryQueryFlux(password: password)
             } else {
-                authRetryCount = 0
                 logger.error("handleUnauthorized: refresh FAILED — signing out")
                 AuthManager.shared.signOut()
                 NotificationCenter.default.post(
@@ -154,11 +131,36 @@ private func handleUnauthorized(password: String) {
     }
 }
 
+/// Single retry after token refresh — signs out on second 401 without further retry.
+private func retryQueryFlux(password: String) {
+    guard let request = buildFluxAPIRequest(password: password) else { return }
+
+    let session = URLSession(configuration: .default, delegate: nil, delegateQueue: nil)
+    let task = session.dataTask(with: request) { data, response, error in
+        let httpResponse = response as? HTTPURLResponse
+        if httpResponse?.statusCode == 401 {
+            logger.error("retryQueryFlux: still 401 after refresh — signing out")
+            DispatchQueue.main.async {
+                AuthManager.shared.signOut()
+                NotificationCenter.default.post(
+                    name: Notification.Name.loginsUpdated,
+                    object: nil,
+                    userInfo: ["keysFailed": true]
+                )
+            }
+            return
+        }
+        handleQueryFluxResponse(data: data, error: error, password: password)
+    }
+    task.resume()
+}
+
 private func handleQueryFluxResponse(data: Data?, error: Error?, password: String) {
     if let data = data {
         do {
             let response = try JSONDecoder().decode(LoginResponse.self, from: data)
             DispatchQueue.main.async {
+                AuthManager.shared.isCompletingOIDCLogin = false
                 NotificationCenter.default.post(
                     name: Notification.Name.loginsUpdated,
                     object: response,
@@ -181,6 +183,7 @@ private func handleQueryFluxResponse(data: Data?, error: Error?, password: Strin
                 logger.error("Response body: \(jsonStr.prefix(500))")
             }
             DispatchQueue.main.async {
+                AuthManager.shared.isCompletingOIDCLogin = false
                 NotificationCenter.default.post(
                     name: Notification.Name.loginsUpdated,
                     object: nil,
@@ -190,6 +193,7 @@ private func handleQueryFluxResponse(data: Data?, error: Error?, password: Strin
         }
     } else {
         DispatchQueue.main.async {
+            AuthManager.shared.isCompletingOIDCLogin = false
             NotificationCenter.default.post(
                 name: Notification.Name.loginsUpdated,
                 object: nil,

--- a/VisionOS/VisionOSApp.swift
+++ b/VisionOS/VisionOSApp.swift
@@ -100,15 +100,9 @@ struct VisionOSApp: App {
                             scooter: scooter,
                             apiResponse: self.apiResponse
                         )
-                        .onReceive(NotificationCenter.default.publisher(for: Notification.Name.logout)) { object in
-                            if (object.userInfo?["logout"]) != nil {
-                                DispatchQueue.main.async {
-                                    self.whereWeAre = WhereWeAre()
-                                }
-                            }
-                        }
                         .onReceive(NotificationCenter.default.publisher(for: Notification.Name.dataUpdated)) { object in
                             if let response = object.userInfo?["data"] as? LoginResponse {
+                                guard AuthManager.shared.isSignedIn else { return }
                                 self.apiResponse.setApiResponse(apiResponse: response)
                                 robots.setApiResponse(apiResponse: self.apiResponse)
                                 hconn.setApiResponse(apiResponse: self.apiResponse)
@@ -135,8 +129,19 @@ struct VisionOSApp: App {
                     }
                 }
             }
+            .onReceive(
+                NotificationCenter.default.publisher(for: .authDidSignOut)
+            ) { _ in
+                self.whereWeAre = WhereWeAre()
+                hconn = nil
+                miele = nil
+                robots = nil
+                car = nil
+                scooter = nil
+            }
             .onChange(of: scenePhase) { _, newPhase in
                 if newPhase == .active && AuthManager.shared.isSignedIn {
+                    guard !AuthManager.shared.isCompletingOIDCLogin else { return }
                     Task {
                         _ = await AuthManager.shared.ensureValidToken()
                         queryFlux(password: WhereWeAre.getPassword() ?? "")

--- a/iOS/FluxHausApp.swift
+++ b/iOS/FluxHausApp.swift
@@ -206,15 +206,9 @@ struct FluxHausApp: App {
                         scooter: scooter,
                         apiResponse: self.apiResponse
                     )
-                    .onReceive(NotificationCenter.default.publisher(for: Notification.Name.logout)) { object in
-                        if (object.userInfo?["logout"]) != nil {
-                            DispatchQueue.main.async {
-                                self.whereWeAre = WhereWeAre()
-                            }
-                        }
-                    }
                     .onReceive(NotificationCenter.default.publisher(for: Notification.Name.dataUpdated)) { object in
                         if let response = object.userInfo?["data"] as? LoginResponse {
+                            guard AuthManager.shared.isSignedIn else { return }
                             self.apiResponse.setApiResponse(apiResponse: response)
                             robots.setApiResponse(apiResponse: self.apiResponse)
                             hconn.setApiResponse(apiResponse: self.apiResponse)
@@ -244,8 +238,19 @@ struct FluxHausApp: App {
                     }
                 }
             }
+            .onReceive(
+                NotificationCenter.default.publisher(for: .authDidSignOut)
+            ) { _ in
+                self.whereWeAre = WhereWeAre()
+                hconn = nil
+                miele = nil
+                robots = nil
+                car = nil
+                scooter = nil
+            }
             .onChange(of: scenePhase) { _, newPhase in
                 if newPhase == .active {
+                    guard !AuthManager.shared.isCompletingOIDCLogin else { return }
                     Task {
                         _ = await AuthManager.shared.ensureValidToken()
                         if AuthManager.shared.isSignedIn {

--- a/iOS/FluxHausApp.swift
+++ b/iOS/FluxHausApp.swift
@@ -156,7 +156,9 @@ struct FluxHausApp: App {
                                 // Register APNs token now that auth is available
                                 Task { await AppDelegate.registerApnsTokenIfReady() }
                                 // Retry any deferred push-to-start token registration
+                                #if !targetEnvironment(macCatalyst)
                                 LiveActivityManager.shared.retryPendingTokenRegistration()
+                                #endif
                             }
 
                             if ((object.userInfo?["homeConnectComplete"]) != nil) == true {
@@ -329,9 +331,11 @@ struct FluxHausApp: App {
     }
 
     func updateLiveActivities(response: LoginResponse) {
+        #if !targetEnvironment(macCatalyst)
         let fluxData = convertLoginResponseToAppData(response: response)
         let devices = convertDataToWidgetDevices(fluxData: fluxData)
         Task { await LiveActivityManager.shared.reconcile(devices: devices) }
+        #endif
     }
 
     private func postNavigation(_ section: String) {

--- a/macOS/MacApp.swift
+++ b/macOS/MacApp.swift
@@ -264,6 +264,7 @@ final class MacAppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func presentQuickChatWindow() {
+        guard AuthManager.shared.isOIDC else { return }
         guard let sharedChat else { return }
         if quickChatWindowController == nil {
             quickChatWindowController = QuickChatWindowController(chat: sharedChat)
@@ -318,6 +319,8 @@ final class MacAppDelegate: NSObject, NSApplicationDelegate {
     private var primaryWindows: [NSWindow] {
         NSApp.windows.filter { window in
             window.identifier?.rawValue != "QuickChatWindow"
+                && window.identifier?.rawValue != "com_apple_SwiftUI_Settings_window"
+                && !(window is NSPanel)
         }
     }
 
@@ -357,6 +360,16 @@ struct MacApp: App {
                             }
                         }
                     }
+                }
+                .onReceive(
+                    NotificationCenter.default.publisher(for: .authDidSignOut)
+                ) { _ in
+                    self.whereWeAre = WhereWeAre()
+                    self.miele = nil
+                    self.hconn = nil
+                    self.robots = nil
+                    self.car = nil
+                    self.scooter = nil
                 }
                 .onOpenURL { url in
                     handleDeepLink(url)
@@ -398,6 +411,13 @@ struct MacApp: App {
                     queryFlux(password: WhereWeAre.getPassword() ?? "")
                 }
                 .keyboardShortcut("r", modifiers: .command)
+
+                Divider()
+
+                Button("Sign Out") {
+                    AuthManager.shared.signOut()
+                }
+                .disabled(!AuthManager.shared.isSignedIn)
             }
 
             CommandGroup(after: .appTermination) {
@@ -457,21 +477,11 @@ struct MacApp: App {
             )
             .onReceive(
                 NotificationCenter.default.publisher(
-                    for: Notification.Name.logout
-                )
-            ) { object in
-                if (object.userInfo?["logout"]) != nil {
-                    DispatchQueue.main.async {
-                        self.whereWeAre = WhereWeAre()
-                    }
-                }
-            }
-            .onReceive(
-                NotificationCenter.default.publisher(
                     for: Notification.Name.dataUpdated
                 )
             ) { object in
                 if let response = object.userInfo?["data"] as? LoginResponse {
+                    guard AuthManager.shared.isSignedIn else { return }
                     self.apiResponse.setApiResponse(apiResponse: response)
                     robots.setApiResponse(apiResponse: self.apiResponse)
                     hconn.setApiResponse(apiResponse: self.apiResponse)

--- a/macOS/SettingsView.swift
+++ b/macOS/SettingsView.swift
@@ -418,11 +418,6 @@ struct SettingsView: View {
                 }
                 Button("Sign Out") {
                     AuthManager.shared.signOut()
-                    NotificationCenter.default.post(
-                        name: Notification.Name.logout,
-                        object: nil,
-                        userInfo: ["logout": true]
-                    )
                 }
             } else {
                 Image(systemName: "xmark.circle.fill")


### PR DESCRIPTION
## Summary

Fixes multiple issues across macOS, iOS, VisionOS, and the widget extension.

### 1. macOS: Easier logout
- Added "Sign Out" to the Navigate command menu (⌘ menu bar)

### 2. macOS: Stale dashboard after sign-out
- Added `.authDidSignOut` notification listener that clears all data models and resets to login view
- Previously, signing out left the dashboard visible with stale data

### 3. macOS: Window management
- Improved `primaryWindows` filter to exclude Settings windows and panels
- Prevents duplicate window creation when the app is already open

### 4. macOS: Quick Chat auth guard
- `presentQuickChatWindow()` now checks `AuthManager.shared.isOIDC` before opening
- Prevents "session expired" errors when not signed in

### 5. iOS/VisionOS: Login race condition
- Replaced unsafe global `authRetryCount` with per-request `retryQueryFlux()`
- Added `isCompletingOIDCLogin` flag to suppress duplicate `queryFlux()` calls during OIDC browser dismissal
- Root cause: `scenePhase` → `.active` fired during OIDC callback, triggering a parallel API call that raced with the login flow

### 6. Unified sign-out notifications
- All platforms now use `.authDidSignOut` (posted by `AuthManager.signOut()`) instead of a mix of `.logout` and `.authDidSignOut`

### 7. Widget extension Mac Catalyst build fix
- These APIs are unavailable on Mac Catalyst (`#if os(iOS)` passes for Catalyst)
- Moved shared helpers (`tintColor`, `isRobot`, etc.) outside the guard so they remain available to all widget code

### Files changed
- `Shared/QueryFlux.swift` — Per-request retry, extracted helpers
- `Shared/AuthManager.swift` — `isCompletingOIDCLogin` flag
- `macOS/MacApp.swift` — Sign Out menu, auth listeners, window filter, Quick Chat guard
- `iOS/FluxHausApp.swift` — Auth listener, login guard, Mac Catalyst guards
- `VisionOS/VisionOSApp.swift` — Auth listener, login guard
- `macOS/SettingsView.swift` — Removed redundant `.logout` post
- `Shared/NotificationSettingsView.swift` — Restructured for Mac Catalyst compat
- `Shared/LiveActivityManager.swift` — Mac Catalyst guard
- `FluxWidget/FluxWidgetLiveActivity.swift` — Mac Catalyst guard, extracted helpers
- `FluxWidget/FluxWidgetLiveActivityLegacy.swift` — Mac Catalyst guard
- `FluxWidget/FluxWidgetWatchViews.swift` — Mac Catalyst guard
- `FluxWidget/FluxWidgetBundle.swift` — Conditional Live Activity registration