### PR TITLE
Harden login resilience against network errors (v1.8.8)

### DIFF
--- a/FluxHaus.xcodeproj/project.pbxproj
+++ b/FluxHaus.xcodeproj/project.pbxproj
@@ -39,6 +39,9 @@
 		37D0A0010000000000000004 /* SuggestionChips.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37D0A0000000000000000001 /* SuggestionChips.swift */; };
 		37DFA1D40B2108B26EA6A811 /* AppliancesViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 632CBC7D25870CBB003E4999 /* AppliancesViewExtensions.swift */; };
 		3861C20261D19FA4398114C0 /* QueryFlux.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6399EA352B9D7901000C8CA4 /* QueryFlux.swift */; };
+		639B4A8E2E4812E0001C9Fda /* QueryFluxWidgetExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639B4A7E2E4812C0001C9F42 /* QueryFluxWidgetExtensions.swift */; };
+		639B4A8E2E4812E0001C9Fb3 /* QueryFluxWidgetExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639B4A7E2E4812C0001C9F42 /* QueryFluxWidgetExtensions.swift */; };
+		639B4A8E2E4812E0001C9F09 /* QueryFluxWidgetExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639B4A7E2E4812C0001C9F42 /* QueryFluxWidgetExtensions.swift */; };
 		3CFA1F5604BA445D83EE6D88 /* ScooterDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8CB990FC6404C8682E3BE62 /* ScooterDetailView.swift */; };
 		3F181EC009E59832882455EA /* WeatherHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAAEBC8C9F79B50F67076AB6 /* WeatherHelpers.swift */; };
 		42E9D45E3DEE4ED4BF3EBB9C /* ScooterDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8CB990FC6404C8682E3BE62 /* ScooterDetailView.swift */; };
@@ -392,6 +395,7 @@
 		6399EA2B2B9D2CCF000C8CA4 /* SystemNotifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemNotifications.swift; sourceTree = "<group>"; };
 		6399EA302B9D3671000C8CA4 /* Login.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Login.swift; sourceTree = "<group>"; };
 		6399EA352B9D7901000C8CA4 /* QueryFlux.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryFlux.swift; sourceTree = "<group>"; };
+		639B4A7E2E4812C0001C9F42 /* QueryFluxWidgetExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryFluxWidgetExtensions.swift; sourceTree = "<group>"; };
 		63A159272C5E9763003F3796 /* LoginStucts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginStucts.swift; sourceTree = "<group>"; };
 		63A39FB42C44391E00E62C09 /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
 		63A39FB62C44391E00E62C09 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
@@ -559,6 +563,7 @@
 				632CBC6F2586C79E003E4988 /* Miele.swift */,
 				635F9D052BAF836C000700FD /* MieleAppliance.swift */,
 				6399EA352B9D7901000C8CA4 /* QueryFlux.swift */,
+				639B4A7E2E4812C0001C9F42 /* QueryFluxWidgetExtensions.swift */,
 				637CE4C42BE71FC000258158 /* RobotDetailView.swift */,
 				635BD66A2B9DF8A6009CEEA9 /* Robots.swift */,
 				6399EA2B2B9D2CCF000C8CA4 /* SystemNotifications.swift */,

--- a/FluxHaus.xcodeproj/project.pbxproj
+++ b/FluxHaus.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		639B4A8E2E4812E0001C9Fb3 /* QueryFluxWidgetExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639B4A7E2E4812C0001C9F42 /* QueryFluxWidgetExtensions.swift */; };
 		639B4A8E2E4812E0001C9F09 /* QueryFluxWidgetExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639B4A7E2E4812C0001C9F42 /* QueryFluxWidgetExtensions.swift */; };
 		639B4A8E2E4812E0001C9FAA /* QueryFluxWidgetExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639B4A7E2E4812C0001C9F42 /* QueryFluxWidgetExtensions.swift */; };
+		639B4A8E2E4812E0001C9FBB /* QueryFluxWidgetExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639B4A7E2E4812C0001C9F42 /* QueryFluxWidgetExtensions.swift */; };
 		3CFA1F5604BA445D83EE6D88 /* ScooterDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8CB990FC6404C8682E3BE62 /* ScooterDetailView.swift */; };
 		3F181EC009E59832882455EA /* WeatherHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAAEBC8C9F79B50F67076AB6 /* WeatherHelpers.swift */; };
 		42E9D45E3DEE4ED4BF3EBB9C /* ScooterDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8CB990FC6404C8682E3BE62 /* ScooterDetailView.swift */; };
@@ -1322,6 +1323,7 @@
 				4C7C9D7BE074D65A480045A1 /* Miele.swift in Sources */,
 				FE6B445E3E47FC883C281562 /* MieleAppliance.swift in Sources */,
 				D8A5836912F3F1DF56628A1C /* QueryFlux.swift in Sources */,
+				639B4A8E2E4812E0001C9FBB /* QueryFluxWidgetExtensions.swift in Sources */,
 				D8D21373FC74A18689317FBB /* RobotDetailView.swift in Sources */,
 				C26CB6CAACD7386DAA031965 /* Robots.swift in Sources */,
 				FFD5C7DCE9B4284348280B90 /* SystemNotifications.swift in Sources */,

--- a/FluxHaus.xcodeproj/project.pbxproj
+++ b/FluxHaus.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		639B4A8E2E4812E0001C9Fda /* QueryFluxWidgetExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639B4A7E2E4812C0001C9F42 /* QueryFluxWidgetExtensions.swift */; };
 		639B4A8E2E4812E0001C9Fb3 /* QueryFluxWidgetExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639B4A7E2E4812C0001C9F42 /* QueryFluxWidgetExtensions.swift */; };
 		639B4A8E2E4812E0001C9F09 /* QueryFluxWidgetExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639B4A7E2E4812C0001C9F42 /* QueryFluxWidgetExtensions.swift */; };
+		639B4A8E2E4812E0001C9FAA /* QueryFluxWidgetExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639B4A7E2E4812C0001C9F42 /* QueryFluxWidgetExtensions.swift */; };
 		3CFA1F5604BA445D83EE6D88 /* ScooterDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8CB990FC6404C8682E3BE62 /* ScooterDetailView.swift */; };
 		3F181EC009E59832882455EA /* WeatherHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAAEBC8C9F79B50F67076AB6 /* WeatherHelpers.swift */; };
 		42E9D45E3DEE4ED4BF3EBB9C /* ScooterDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8CB990FC6404C8682E3BE62 /* ScooterDetailView.swift */; };
@@ -1071,6 +1072,7 @@
 				9D14B888828F5291C3A1B2D5 /* Miele.swift in Sources */,
 				E0FFED608140DA7EB6F6D326 /* MieleAppliance.swift in Sources */,
 				3861C20261D19FA4398114C0 /* QueryFlux.swift in Sources */,
+				639B4A8E2E4812E0001C9F09 /* QueryFluxWidgetExtensions.swift in Sources */,
 				323C8C60BEA480D9040C3B37 /* RobotDetailView.swift in Sources */,
 				A7EB26F31FDF9BA1C1907FEE /* Robots.swift in Sources */,
 				1EE958BBEBFBE734319E4BAB /* SystemNotifications.swift in Sources */,
@@ -1148,6 +1150,7 @@
 				636B9B3A258E57D400DE97BD /* WeatherView.swift in Sources */,
 				63610D2E2BB883DA0048B9FF /* ApplianceViewHelpers.swift in Sources */,
 				6399EA362B9D7901000C8CA4 /* QueryFlux.swift in Sources */,
+				639B4A8E2E4812E0001C9Fda /* QueryFluxWidgetExtensions.swift in Sources */,
 				9F0AB88C6586E3EEFCE46F8B /* SceneService.swift in Sources */,
 				RD0003000000000000000002 /* RadarService.swift in Sources */,
 				RM0001000000000000000001 /* RadarMapViews.swift in Sources */,
@@ -1201,6 +1204,7 @@
 				636BF1EE2C5D8EC900C1244C /* Miele.swift in Sources */,
 				636BF1EF2C5D8EC900C1244C /* Robots.swift in Sources */,
 				636BF1E82C5D8E1400C1244C /* QueryFlux.swift in Sources */,
+				639B4A8E2E4812E0001C9FAA /* QueryFluxWidgetExtensions.swift in Sources */,
 				636BF1E72C5D8B8400C1244C /* WhereWeAre.swift in Sources */,
 				77CDDA9FA1A142A79B3AEB86 /* AuthManager.swift in Sources */,
 				637BC6322C5BDA8000E7884E /* FluxWidget.swift in Sources */,
@@ -1253,6 +1257,7 @@
 				63DBD7352B954215006603D0 /* VisionOSApp.swift in Sources */,
 				63BCF7572C63FABB001D4375 /* Api.swift in Sources */,
 				6399EA382B9D7901000C8CA4 /* QueryFlux.swift in Sources */,
+				639B4A8E2E4812E0001C9Fb3 /* QueryFluxWidgetExtensions.swift in Sources */,
 				36D5A7173B8D7FC007D2B1C0 /* SceneService.swift in Sources */,
 				RD0003000000000000000003 /* RadarService.swift in Sources */,
 				RM0001000000000000000002 /* RadarMapViews.swift in Sources */,

--- a/FluxHaus.xcodeproj/project.pbxproj
+++ b/FluxHaus.xcodeproj/project.pbxproj
@@ -1375,7 +1375,7 @@
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.7;
+				MARKETING_VERSION = 1.8.8;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.davidjensenius.FluxHaus.Tests-macOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
@@ -1441,7 +1441,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.7;
+				MARKETING_VERSION = 1.8.8;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -1502,7 +1502,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.7;
+				MARKETING_VERSION = 1.8.8;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -1530,7 +1530,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.7;
+				MARKETING_VERSION = 1.8.8;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus;
 				PRODUCT_NAME = FluxHaus;
 				SDKROOT = iphoneos;
@@ -1563,7 +1563,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.7;
+				MARKETING_VERSION = 1.8.8;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus;
 				PRODUCT_NAME = FluxHaus;
 				SDKROOT = iphoneos;
@@ -1592,7 +1592,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.7;
+				MARKETING_VERSION = 1.8.8;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.davidjensenius.Tests-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1619,7 +1619,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.7;
+				MARKETING_VERSION = 1.8.8;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.davidjensenius.Tests-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1658,7 +1658,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.8.7;
+				MARKETING_VERSION = 1.8.8;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus.FluxWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1697,7 +1697,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.8.7;
+				MARKETING_VERSION = 1.8.8;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus.FluxWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1734,7 +1734,7 @@
 					"@executable_path/Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.8.7;
+				MARKETING_VERSION = 1.8.8;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus;
 				PRODUCT_MODULE_NAME = FluxHaus;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1772,7 +1772,7 @@
 					"@executable_path/Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.8.7;
+				MARKETING_VERSION = 1.8.8;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus;
 				PRODUCT_MODULE_NAME = FluxHaus;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1798,7 +1798,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.8.7;
+				MARKETING_VERSION = 1.8.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jensenius.fluxhaus.VisionOSTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = xros;
@@ -1824,7 +1824,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.8.7;
+				MARKETING_VERSION = 1.8.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jensenius.fluxhaus.VisionOSTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = xros;
@@ -1871,7 +1871,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.7;
+				MARKETING_VERSION = 1.8.8;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus;
 				PRODUCT_NAME = FluxHaus;
 				SDKROOT = macosx;
@@ -1911,7 +1911,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.7;
+				MARKETING_VERSION = 1.8.8;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus;
 				PRODUCT_NAME = FluxHaus;
 				SDKROOT = macosx;
@@ -1927,7 +1927,7 @@
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.7;
+				MARKETING_VERSION = 1.8.8;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.davidjensenius.FluxHaus.Tests-macOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;

--- a/Shared/QueryFlux.swift
+++ b/Shared/QueryFlux.swift
@@ -10,6 +10,39 @@ import os
 
 private let logger = Logger(subsystem: "io.fluxhaus.FluxHaus", category: "QueryFlux")
 
+// MARK: - Error Categorization
+enum QueryFluxErrorType {
+    case transientNetworkError(Error)
+    case authenticationFailed(String)
+    case serverError(Int)
+    case responseDecodeError
+    case unknown(String)
+
+    var isTransient: Bool {
+        switch self {
+        case .transientNetworkError:
+            return true
+        default:
+            return false
+        }
+    }
+
+    var userMessage: String {
+        switch self {
+        case .authenticationFailed(let msg):
+            return msg
+        case .responseDecodeError:
+            return "Failed to load data"
+        case .serverError(let code):
+            return "Server error (\(code))"
+        case .transientNetworkError:
+            return "Network error"
+        case .unknown(let msg):
+            return msg
+        }
+    }
+}
+
 private struct CsrfResponse: Decodable {
     let csrfToken: String
 }
@@ -63,6 +96,30 @@ class BasicAuthDelegate: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
     }
 }
 
+// MARK: - Retry Helper
+private struct RetryConfig {
+    let maxRetries: Int = 3
+    let initialDelayMs: UInt32 = 500
+
+    func delayMs(for attempt: Int) -> UInt32 {
+        UInt32(Double(initialDelayMs) * pow(2.0, Double(attempt)))
+    }
+}
+
+private func isTransientNetworkError(_ error: Error) -> Bool {
+    let nsError = error as NSError
+    let transientCodes = [
+        NSURLErrorTimedOut,
+        NSURLErrorNetworkConnectionLost,
+        NSURLErrorNotConnectedToInternet,
+        NSURLErrorCannotConnectToHost,
+        NSURLErrorCannotFindHost,
+        NSURLErrorDNSLookupFailed,
+        NSURLErrorResourceUnavailable
+    ]
+    return transientCodes.contains(nsError.code)
+}
+
 private func buildFluxAPIRequest(password: String) -> URLRequest? {
     var components = URLComponents()
     components.scheme = "https"
@@ -84,16 +141,33 @@ private func buildFluxAPIRequest(password: String) -> URLRequest? {
 }
 
 func queryFlux(password: String) {
+    queryFluxWithRetry(password: password, attempt: 0)
+}
+
+private func queryFluxWithRetry(password: String, attempt: Int) {
     guard let request = buildFluxAPIRequest(password: password) else { return }
 
     let session = URLSession(configuration: .default, delegate: nil, delegateQueue: nil)
     let task = session.dataTask(with: request) { data, response, error in
         let httpResponse = response as? HTTPURLResponse
+
         if httpResponse?.statusCode == 401 {
             handleUnauthorized(password: password)
             return
         }
-        handleQueryFluxResponse(data: data, error: error, password: password)
+
+        if let error = error {
+            if isTransientNetworkError(error) && attempt < RetryConfig().maxRetries {
+                let delayMs = RetryConfig().delayMs(for: attempt)
+                logger.warning("queryFlux: transient error on attempt \(attempt + 1), retrying in \(delayMs)ms")
+                DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(Int(delayMs))) {
+                    queryFluxWithRetry(password: password, attempt: attempt + 1)
+                }
+                return
+            }
+        }
+
+        handleQueryFluxResponse(data: data, error: error, password: password, isRetry: attempt > 0)
     }
     task.resume()
 }
@@ -155,7 +229,7 @@ private func retryQueryFlux(password: String) {
     task.resume()
 }
 
-private func handleQueryFluxResponse(data: Data?, error: Error?, password: String) {
+private func handleQueryFluxResponse(data: Data?, error: Error?, password: String, isRetry: Bool = false) {
     if let data = data {
         do {
             let response = try JSONDecoder().decode(LoginResponse.self, from: data)
@@ -195,14 +269,29 @@ private func handleQueryFluxResponse(data: Data?, error: Error?, password: Strin
                 )
             }
         }
+    } else if let error = error {
+        // Only post error for non-transient failures
+        if !isTransientNetworkError(error) {
+            logger.error("handleQueryFluxResponse: non-transient error: \(error.localizedDescription)")
+            DispatchQueue.main.async {
+                AuthManager.shared.isCompletingOIDCLogin = false
+                NotificationCenter.default.post(
+                    name: Notification.Name.loginsUpdated,
+                    object: nil,
+                    userInfo: ["loginError": error.localizedDescription]
+                )
+            }
+        } else {
+            // Transient network error but retries exhausted
+            let msg = "transient error exhausted after retries"
+            logger.error("handleQueryFluxResponse: \(msg): \(error.localizedDescription)")
+            DispatchQueue.main.async {
+                AuthManager.shared.isCompletingOIDCLogin = false
+            }
+        }
     } else {
         DispatchQueue.main.async {
             AuthManager.shared.isCompletingOIDCLogin = false
-            NotificationCenter.default.post(
-                name: Notification.Name.loginsUpdated,
-                object: nil,
-                userInfo: ["loginError": error?.localizedDescription ?? "Network error"]
-            )
         }
     }
 }
@@ -318,182 +407,4 @@ func convertLoginResponseToAppData(response: LoginResponse) -> FluxData {
         dryer: dryer,
         washer: washer
     )
-}
-
-struct WidgetDevice: Codable, Equatable, Hashable {
-    var name: String
-    var progress: Int
-    var icon: String
-    var trailingText: String
-    var shortText: String
-    var running: Bool
-    var battery: Int?
-    var programName: String?
-}
-
-/// Format a time remaining value (in minutes) as a human-readable string.
-/// Under 60 minutes: "30m". 60+ minutes: "2h 36m".
-func formatTimeRemaining(minutes: Int) -> String {
-    if minutes < 60 {
-        return "\(minutes)m"
-    }
-    let finishDate = Date().addingTimeInterval(Double(minutes) * 60)
-    let formatter = DateFormatter()
-    formatter.timeStyle = .short
-    formatter.dateStyle = .none
-    return formatter.string(from: finishDate)
-}
-
-/// Format a duration in minutes for display in appliance views.
-/// Under 60 minutes: "30 min". 60+ minutes: "2h 36 min".
-func formatDurationMinutes(_ minutes: Int) -> String {
-    if minutes < 60 {
-        return "\(minutes) min"
-    }
-    let hours = minutes / 60
-    let remainingMinutes = minutes % 60
-    if remainingMinutes == 0 {
-        return "\(hours)h"
-    }
-    return "\(hours)h \(remainingMinutes) min"
-}
-
-// swiftlint:disable:next function_body_length
-func convertDataToWidgetDevices(fluxData: FluxData) -> [WidgetDevice] {
-    var returnValue: [WidgetDevice] = []
-
-    let dishwasherMinutes = (fluxData.dishwasher?.remainingTime ?? 0) / 60
-    let dishWasherReminingTime = formatTimeRemaining(minutes: dishwasherMinutes)
-    let dishwasherDisplayName = fluxData.dishwasher?.activeProgram?.displayName
-    var dishwasherTrailingText = dishWasherReminingTime
-    if let programName = dishwasherDisplayName {
-        dishwasherTrailingText = "\(programName) ⋅ \(dishwasherTrailingText)"
-    }
-    if fluxData.dishwasher != nil && fluxData.dishwasher?.operationState.rawValue != "Run" {
-        dishwasherTrailingText = fluxData.dishwasher!.operationState.rawValue + " ⋅ \(dishwasherTrailingText)"
-    }
-
-    if fluxData.dishwasher?.operationState.rawValue == "Finished" {
-        returnValue.append(
-            WidgetDevice(
-                name: "Dishwasher",
-                progress: 0,
-                icon: "dishwasher",
-                trailingText: "",
-                shortText: "",
-                running: false,
-                programName: dishwasherDisplayName
-            )
-        )
-    } else {
-        returnValue.append(
-            WidgetDevice(
-                name: "Dishwasher",
-                progress: Int(fluxData.dishwasher?.programProgress ?? 0),
-                icon: "dishwasher",
-                trailingText: dishwasherTrailingText,
-                shortText: dishWasherReminingTime,
-                running: fluxData.dishwasher?.programProgress ?? 0 > 0,
-                programName: dishwasherDisplayName
-            )
-        )
-    }
-
-    let washerTimeRunning = fluxData.washer?.timeRunning ?? 0
-    let washerTimeRemaining = fluxData.washer?.timeRemaining ?? 0
-    var washerProrgress = 0
-    if washerTimeRunning > 0 {
-        washerProrgress = Int(Double(washerTimeRunning) / Double(washerTimeRemaining + washerTimeRunning) * 100)
-    }
-
-    let washerReminingTime = formatTimeRemaining(minutes: fluxData.washer?.timeRemaining ?? 0)
-    var washerTrailingText = washerReminingTime
-    if let programName = fluxData.washer?.programName,
-       !programName.trimmingCharacters(in: .whitespaces).isEmpty {
-        washerTrailingText = "\(formatApplianceProgramName(programName)) ⋅ \(washerTrailingText)"
-    }
-    if fluxData.washer != nil && fluxData.washer?.status != "In use",
-       let status = fluxData.washer?.status {
-        washerTrailingText = "\(status) ⋅ \(washerTrailingText)"
-    }
-
-    returnValue.append(
-        WidgetDevice(
-            name: "Washer",
-            progress: washerProrgress,
-            icon: "washer",
-            trailingText: washerTrailingText,
-            shortText: washerReminingTime,
-            running: fluxData.washer?.timeRemaining ?? 0 > 0,
-            programName: fluxData.washer?.programName.map { formatApplianceProgramName($0) }
-        )
-    )
-
-    let dryerTimeRunning = fluxData.dryer?.timeRunning ?? 0
-    let dryerTimeRemaining = fluxData.dryer?.timeRemaining ?? 1
-    var dryerProgress = 0
-    if dryerTimeRunning  > 0 {
-        dryerProgress = Int(Double(dryerTimeRunning) / Double(dryerTimeRemaining + dryerTimeRunning) * 100)
-    }
-    let dryerReminingTime = formatTimeRemaining(minutes: fluxData.dryer?.timeRemaining ?? 0)
-    var dryerTrailingText = dryerReminingTime
-    if let programName = fluxData.dryer?.programName,
-       !programName.trimmingCharacters(in: .whitespaces).isEmpty {
-        dryerTrailingText = "\(formatApplianceProgramName(programName)) ⋅ \(dryerTrailingText)"
-    }
-    if fluxData.dryer != nil && fluxData.dryer?.status != "In use",
-       let status = fluxData.dryer?.status {
-        dryerTrailingText = "\(status) ⋅ \(dryerTrailingText)"
-    }
-
-    returnValue.append(
-        WidgetDevice(
-            name: "Dryer",
-            progress: dryerProgress,
-            icon: "dryer",
-            trailingText: dryerTrailingText,
-            shortText: dryerReminingTime,
-            running: fluxData.dryer?.timeRemaining ?? 0 > 0,
-            programName: fluxData.dryer?.programName.map { formatApplianceProgramName($0) }
-        )
-    )
-
-    returnValue.append(
-        WidgetDevice(
-            name: "BroomBot",
-            progress: fluxData.broomBot?.batteryLevel ?? 0,
-            icon: "fan",
-            trailingText: fluxData.broomBot?.running ?? false ? "On" : "Off",
-            shortText: fluxData.broomBot?.running ?? false ? "On" : "Off",
-            running: fluxData.broomBot?.running ?? false,
-            battery: fluxData.broomBot?.batteryLevel
-        )
-    )
-
-    returnValue.append(
-        WidgetDevice(
-            name: "MopBot",
-            progress: fluxData.mopBot?.batteryLevel ?? 0,
-            icon: "humidifier.and.droplets",
-            trailingText: fluxData.mopBot?.running ?? false ? "On" : "Off",
-            shortText: fluxData.mopBot?.running ?? false ? "On" : "Off",
-            running: fluxData.mopBot?.running ?? false,
-            battery: fluxData.mopBot?.batteryLevel
-        )
-    )
-
-    if let car = fluxData.car {
-        returnValue.append(
-            WidgetDevice(
-                name: "Car",
-                progress: car.batteryLevel,
-                icon: "car",
-                trailingText: "Range \(car.distance) km ⋅ \(car.batteryLevel)% ",
-                shortText: "\(car.distance) km",
-                running: false
-            )
-        )
-    }
-
-    return returnValue
 }

--- a/Shared/QueryFlux.swift
+++ b/Shared/QueryFlux.swift
@@ -108,6 +108,7 @@ private struct RetryConfig {
 
 private func isTransientNetworkError(_ error: Error) -> Bool {
     let nsError = error as NSError
+    guard nsError.domain == NSURLErrorDomain else { return false }
     let transientCodes = [
         NSURLErrorTimedOut,
         NSURLErrorNetworkConnectionLost,
@@ -287,6 +288,11 @@ private func handleQueryFluxResponse(data: Data?, error: Error?, password: Strin
             logger.error("handleQueryFluxResponse: \(msg): \(error.localizedDescription)")
             DispatchQueue.main.async {
                 AuthManager.shared.isCompletingOIDCLogin = false
+                NotificationCenter.default.post(
+                    name: Notification.Name.loginsUpdated,
+                    object: nil,
+                    userInfo: ["loginError": "Network error"]
+                )
             }
         }
     } else {

--- a/Shared/QueryFlux.swift
+++ b/Shared/QueryFlux.swift
@@ -10,37 +10,12 @@ import os
 
 private let logger = Logger(subsystem: "io.fluxhaus.FluxHaus", category: "QueryFlux")
 
-// MARK: - Error Categorization
-enum QueryFluxErrorType {
-    case transientNetworkError(Error)
-    case authenticationFailed(String)
-    case serverError(Int)
-    case responseDecodeError
-    case unknown(String)
+// MARK: - Helper Functions
 
-    var isTransient: Bool {
-        switch self {
-        case .transientNetworkError:
-            return true
-        default:
-            return false
-        }
-    }
-
-    var userMessage: String {
-        switch self {
-        case .authenticationFailed(let msg):
-            return msg
-        case .responseDecodeError:
-            return "Failed to load data"
-        case .serverError(let code):
-            return "Server error (\(code))"
-        case .transientNetworkError:
-            return "Network error"
-        case .unknown(let msg):
-            return msg
-        }
-    }
+/// Check if a login error message indicates an authentication failure (vs transient/server issue)
+func isAuthFailureMessage(_ message: String) -> Bool {
+    let lower = message.lowercased()
+    return lower.contains("password") || lower.contains("incorrect") || lower.contains("unauthorized")
 }
 
 private struct CsrfResponse: Decodable {
@@ -168,7 +143,7 @@ private func queryFluxWithRetry(password: String, attempt: Int) {
             }
         }
 
-        handleQueryFluxResponse(data: data, error: error, password: password, isRetry: attempt > 0)
+        handleQueryFluxResponse(data: data, error: error, password: password)
     }
     task.resume()
 }
@@ -230,7 +205,7 @@ private func retryQueryFlux(password: String) {
     task.resume()
 }
 
-private func handleQueryFluxResponse(data: Data?, error: Error?, password: String, isRetry: Bool = false) {
+private func handleQueryFluxResponse(data: Data?, error: Error?, password: String) {
     if let data = data {
         do {
             let response = try JSONDecoder().decode(LoginResponse.self, from: data)

--- a/Shared/QueryFluxWidgetExtensions.swift
+++ b/Shared/QueryFluxWidgetExtensions.swift
@@ -1,0 +1,186 @@
+//
+//  QueryFluxWidgetExtensions.swift
+//  FluxHaus
+//
+//  Created by David Jensenius on 2024-03-10.
+//
+
+import Foundation
+
+struct WidgetDevice: Codable, Equatable, Hashable {
+    var name: String
+    var progress: Int
+    var icon: String
+    var trailingText: String
+    var shortText: String
+    var running: Bool
+    var battery: Int?
+    var programName: String?
+}
+
+/// Format a time remaining value (in minutes) as a human-readable string.
+/// Under 60 minutes: "30m". 60+ minutes: "2h 36m".
+func formatTimeRemaining(minutes: Int) -> String {
+    if minutes < 60 {
+        return "\(minutes)m"
+    }
+    let finishDate = Date().addingTimeInterval(Double(minutes) * 60)
+    let formatter = DateFormatter()
+    formatter.timeStyle = .short
+    formatter.dateStyle = .none
+    return formatter.string(from: finishDate)
+}
+
+/// Format a duration in minutes for display in appliance views.
+/// Under 60 minutes: "30 min". 60+ minutes: "2h 36 min".
+func formatDurationMinutes(_ minutes: Int) -> String {
+    if minutes < 60 {
+        return "\(minutes) min"
+    }
+    let hours = minutes / 60
+    let remainingMinutes = minutes % 60
+    if remainingMinutes == 0 {
+        return "\(hours)h"
+    }
+    return "\(hours)h \(remainingMinutes) min"
+}
+
+// swiftlint:disable:next function_body_length
+func convertDataToWidgetDevices(fluxData: FluxData) -> [WidgetDevice] {
+    var returnValue: [WidgetDevice] = []
+
+    let dishwasherMinutes = (fluxData.dishwasher?.remainingTime ?? 0) / 60
+    let dishWasherReminingTime = formatTimeRemaining(minutes: dishwasherMinutes)
+    let dishwasherDisplayName = fluxData.dishwasher?.activeProgram?.displayName
+    var dishwasherTrailingText = dishWasherReminingTime
+    if let programName = dishwasherDisplayName {
+        dishwasherTrailingText = "\(programName) ⋅ \(dishwasherTrailingText)"
+    }
+    if fluxData.dishwasher != nil && fluxData.dishwasher?.operationState.rawValue != "Run" {
+        dishwasherTrailingText = fluxData.dishwasher!.operationState.rawValue + " ⋅ \(dishwasherTrailingText)"
+    }
+
+    if fluxData.dishwasher?.operationState.rawValue == "Finished" {
+        returnValue.append(
+            WidgetDevice(
+                name: "Dishwasher",
+                progress: 0,
+                icon: "dishwasher",
+                trailingText: "",
+                shortText: "",
+                running: false,
+                programName: dishwasherDisplayName
+            )
+        )
+    } else {
+        returnValue.append(
+            WidgetDevice(
+                name: "Dishwasher",
+                progress: Int(fluxData.dishwasher?.programProgress ?? 0),
+                icon: "dishwasher",
+                trailingText: dishwasherTrailingText,
+                shortText: dishWasherReminingTime,
+                running: fluxData.dishwasher?.programProgress ?? 0 > 0,
+                programName: dishwasherDisplayName
+            )
+        )
+    }
+
+    let washerTimeRunning = fluxData.washer?.timeRunning ?? 0
+    let washerTimeRemaining = fluxData.washer?.timeRemaining ?? 0
+    var washerProrgress = 0
+    if washerTimeRunning > 0 {
+        washerProrgress = Int(Double(washerTimeRunning) / Double(washerTimeRemaining + washerTimeRunning) * 100)
+    }
+
+    let washerReminingTime = formatTimeRemaining(minutes: fluxData.washer?.timeRemaining ?? 0)
+    var washerTrailingText = washerReminingTime
+    if let programName = fluxData.washer?.programName,
+       !programName.trimmingCharacters(in: .whitespaces).isEmpty {
+        washerTrailingText = "\(formatApplianceProgramName(programName)) ⋅ \(washerTrailingText)"
+    }
+    if fluxData.washer != nil && fluxData.washer?.status != "In use",
+       let status = fluxData.washer?.status {
+        washerTrailingText = "\(status) ⋅ \(washerTrailingText)"
+    }
+
+    returnValue.append(
+        WidgetDevice(
+            name: "Washer",
+            progress: washerProrgress,
+            icon: "washer",
+            trailingText: washerTrailingText,
+            shortText: washerReminingTime,
+            running: fluxData.washer?.timeRemaining ?? 0 > 0,
+            programName: fluxData.washer?.programName.map { formatApplianceProgramName($0) }
+        )
+    )
+
+    let dryerTimeRunning = fluxData.dryer?.timeRunning ?? 0
+    let dryerTimeRemaining = fluxData.dryer?.timeRemaining ?? 1
+    var dryerProgress = 0
+    if dryerTimeRunning  > 0 {
+        dryerProgress = Int(Double(dryerTimeRunning) / Double(dryerTimeRemaining + dryerTimeRunning) * 100)
+    }
+    let dryerReminingTime = formatTimeRemaining(minutes: fluxData.dryer?.timeRemaining ?? 0)
+    var dryerTrailingText = dryerReminingTime
+    if let programName = fluxData.dryer?.programName,
+       !programName.trimmingCharacters(in: .whitespaces).isEmpty {
+        dryerTrailingText = "\(formatApplianceProgramName(programName)) ⋅ \(dryerTrailingText)"
+    }
+    if fluxData.dryer != nil && fluxData.dryer?.status != "In use",
+       let status = fluxData.dryer?.status {
+        dryerTrailingText = "\(status) ⋅ \(dryerTrailingText)"
+    }
+
+    returnValue.append(
+        WidgetDevice(
+            name: "Dryer",
+            progress: dryerProgress,
+            icon: "dryer",
+            trailingText: dryerTrailingText,
+            shortText: dryerReminingTime,
+            running: fluxData.dryer?.timeRemaining ?? 0 > 0,
+            programName: fluxData.dryer?.programName.map { formatApplianceProgramName($0) }
+        )
+    )
+
+    returnValue.append(
+        WidgetDevice(
+            name: "BroomBot",
+            progress: fluxData.broomBot?.batteryLevel ?? 0,
+            icon: "fan",
+            trailingText: fluxData.broomBot?.running ?? false ? "On" : "Off",
+            shortText: fluxData.broomBot?.running ?? false ? "On" : "Off",
+            running: fluxData.broomBot?.running ?? false,
+            battery: fluxData.broomBot?.batteryLevel
+        )
+    )
+
+    returnValue.append(
+        WidgetDevice(
+            name: "MopBot",
+            progress: fluxData.mopBot?.batteryLevel ?? 0,
+            icon: "humidifier.and.droplets",
+            trailingText: fluxData.mopBot?.running ?? false ? "On" : "Off",
+            shortText: fluxData.mopBot?.running ?? false ? "On" : "Off",
+            running: fluxData.mopBot?.running ?? false,
+            battery: fluxData.mopBot?.batteryLevel
+        )
+    )
+
+    if let car = fluxData.car {
+        returnValue.append(
+            WidgetDevice(
+                name: "Car",
+                progress: car.batteryLevel,
+                icon: "car",
+                trailingText: "Range \(car.distance) km ⋅ \(car.batteryLevel)% ",
+                shortText: "\(car.distance) km",
+                running: false
+            )
+        )
+    }
+
+    return returnValue
+}

--- a/Shared/QueryFluxWidgetExtensions.swift
+++ b/Shared/QueryFluxWidgetExtensions.swift
@@ -18,8 +18,8 @@ struct WidgetDevice: Codable, Equatable, Hashable {
     var programName: String?
 }
 
-/// Format a time remaining value (in minutes) as a human-readable string.
-/// Under 60 minutes: "30m". 60+ minutes: "2h 36m".
+/// Format a time remaining value (in minutes) as a human-readable finish time.
+/// Under 60 minutes: "30m". 60+ minutes: "2:36 PM" (localized clock time).
 func formatTimeRemaining(minutes: Int) -> String {
     if minutes < 60 {
         return "\(minutes)m"
@@ -50,9 +50,9 @@ func convertDataToWidgetDevices(fluxData: FluxData) -> [WidgetDevice] {
     var returnValue: [WidgetDevice] = []
 
     let dishwasherMinutes = (fluxData.dishwasher?.remainingTime ?? 0) / 60
-    let dishWasherReminingTime = formatTimeRemaining(minutes: dishwasherMinutes)
+    let dishwasherRemainingTime = formatTimeRemaining(minutes: dishwasherMinutes)
     let dishwasherDisplayName = fluxData.dishwasher?.activeProgram?.displayName
-    var dishwasherTrailingText = dishWasherReminingTime
+    var dishwasherTrailingText = dishwasherRemainingTime
     if let programName = dishwasherDisplayName {
         dishwasherTrailingText = "\(programName) ⋅ \(dishwasherTrailingText)"
     }
@@ -79,7 +79,7 @@ func convertDataToWidgetDevices(fluxData: FluxData) -> [WidgetDevice] {
                 progress: Int(fluxData.dishwasher?.programProgress ?? 0),
                 icon: "dishwasher",
                 trailingText: dishwasherTrailingText,
-                shortText: dishWasherReminingTime,
+                shortText: dishwasherRemainingTime,
                 running: fluxData.dishwasher?.programProgress ?? 0 > 0,
                 programName: dishwasherDisplayName
             )
@@ -88,13 +88,13 @@ func convertDataToWidgetDevices(fluxData: FluxData) -> [WidgetDevice] {
 
     let washerTimeRunning = fluxData.washer?.timeRunning ?? 0
     let washerTimeRemaining = fluxData.washer?.timeRemaining ?? 0
-    var washerProrgress = 0
+    var washerProgress = 0
     if washerTimeRunning > 0 {
-        washerProrgress = Int(Double(washerTimeRunning) / Double(washerTimeRemaining + washerTimeRunning) * 100)
+        washerProgress = Int(Double(washerTimeRunning) / Double(washerTimeRemaining + washerTimeRunning) * 100)
     }
 
-    let washerReminingTime = formatTimeRemaining(minutes: fluxData.washer?.timeRemaining ?? 0)
-    var washerTrailingText = washerReminingTime
+    let washerRemainingTime = formatTimeRemaining(minutes: fluxData.washer?.timeRemaining ?? 0)
+    var washerTrailingText = washerRemainingTime
     if let programName = fluxData.washer?.programName,
        !programName.trimmingCharacters(in: .whitespaces).isEmpty {
         washerTrailingText = "\(formatApplianceProgramName(programName)) ⋅ \(washerTrailingText)"
@@ -107,10 +107,10 @@ func convertDataToWidgetDevices(fluxData: FluxData) -> [WidgetDevice] {
     returnValue.append(
         WidgetDevice(
             name: "Washer",
-            progress: washerProrgress,
+            progress: washerProgress,
             icon: "washer",
             trailingText: washerTrailingText,
-            shortText: washerReminingTime,
+            shortText: washerRemainingTime,
             running: fluxData.washer?.timeRemaining ?? 0 > 0,
             programName: fluxData.washer?.programName.map { formatApplianceProgramName($0) }
         )
@@ -122,8 +122,8 @@ func convertDataToWidgetDevices(fluxData: FluxData) -> [WidgetDevice] {
     if dryerTimeRunning  > 0 {
         dryerProgress = Int(Double(dryerTimeRunning) / Double(dryerTimeRemaining + dryerTimeRunning) * 100)
     }
-    let dryerReminingTime = formatTimeRemaining(minutes: fluxData.dryer?.timeRemaining ?? 0)
-    var dryerTrailingText = dryerReminingTime
+    let dryerRemainingTime = formatTimeRemaining(minutes: fluxData.dryer?.timeRemaining ?? 0)
+    var dryerTrailingText = dryerRemainingTime
     if let programName = fluxData.dryer?.programName,
        !programName.trimmingCharacters(in: .whitespaces).isEmpty {
         dryerTrailingText = "\(formatApplianceProgramName(programName)) ⋅ \(dryerTrailingText)"
@@ -139,7 +139,7 @@ func convertDataToWidgetDevices(fluxData: FluxData) -> [WidgetDevice] {
             progress: dryerProgress,
             icon: "dryer",
             trailingText: dryerTrailingText,
-            shortText: dryerReminingTime,
+            shortText: dryerRemainingTime,
             running: fluxData.dryer?.timeRemaining ?? 0 > 0,
             programName: fluxData.dryer?.programName.map { formatApplianceProgramName($0) }
         )

--- a/VisionOS/VisionOSApp.swift
+++ b/VisionOS/VisionOSApp.swift
@@ -67,16 +67,15 @@ struct VisionOSApp: App {
                                 let isSignedIn = AuthManager.shared.isSignedIn
                                 appLogger.warning("loginError: \(errMsg), isSignedIn=\(isSignedIn)")
                                 if !AuthManager.shared.isSignedIn {
-                                    // Only clear keychain for auth-related failures, not network errors
+                                    // Only clear keychain for actual auth failures
                                     let isAuthFailure = errMsg.lowercased().contains("password") ||
                                                        errMsg.lowercased().contains("incorrect") ||
-                                                       errMsg.lowercased().contains("unauthorized") ||
-                                                       errMsg.lowercased().contains("failed to load data")
+                                                       errMsg.lowercased().contains("unauthorized")
                                     if isAuthFailure {
                                         appLogger.warning("Clearing keychain due to auth failure: \(errMsg)")
                                         whereWeAre.deleteKeyChainPasword()
                                     } else {
-                                        appLogger.warning("Not clearing keychain for transient error: \(errMsg)")
+                                        appLogger.warning("Not clearing keychain for: \(errMsg)")
                                     }
                                 }
                             }

--- a/VisionOS/VisionOSApp.swift
+++ b/VisionOS/VisionOSApp.swift
@@ -67,11 +67,7 @@ struct VisionOSApp: App {
                                 let isSignedIn = AuthManager.shared.isSignedIn
                                 appLogger.warning("loginError: \(errMsg), isSignedIn=\(isSignedIn)")
                                 if !AuthManager.shared.isSignedIn {
-                                    // Only clear keychain for actual auth failures
-                                    let isAuthFailure = errMsg.lowercased().contains("password") ||
-                                                       errMsg.lowercased().contains("incorrect") ||
-                                                       errMsg.lowercased().contains("unauthorized")
-                                    if isAuthFailure {
+                                    if isAuthFailureMessage(errMsg) {
                                         appLogger.warning("Clearing keychain due to auth failure: \(errMsg)")
                                         whereWeAre.deleteKeyChainPasword()
                                     } else {

--- a/VisionOS/VisionOSApp.swift
+++ b/VisionOS/VisionOSApp.swift
@@ -67,8 +67,17 @@ struct VisionOSApp: App {
                                 let isSignedIn = AuthManager.shared.isSignedIn
                                 appLogger.warning("loginError: \(errMsg), isSignedIn=\(isSignedIn)")
                                 if !AuthManager.shared.isSignedIn {
-                                    appLogger.warning("Clearing keychain due to loginError while signed out")
-                                    whereWeAre.deleteKeyChainPasword()
+                                    // Only clear keychain for auth-related failures, not network errors
+                                    let isAuthFailure = errMsg.lowercased().contains("password") ||
+                                                       errMsg.lowercased().contains("incorrect") ||
+                                                       errMsg.lowercased().contains("unauthorized") ||
+                                                       errMsg.lowercased().contains("failed to load data")
+                                    if isAuthFailure {
+                                        appLogger.warning("Clearing keychain due to auth failure: \(errMsg)")
+                                        whereWeAre.deleteKeyChainPasword()
+                                    } else {
+                                        appLogger.warning("Not clearing keychain for transient error: \(errMsg)")
+                                    }
                                 }
                             }
                         }

--- a/iOS/FluxHausApp.swift
+++ b/iOS/FluxHausApp.swift
@@ -181,8 +181,17 @@ struct FluxHausApp: App {
                                 let isSignedIn = AuthManager.shared.isSignedIn
                                 appLogger.warning("loginError: \(errMsg), isSignedIn=\(isSignedIn)")
                                 if !AuthManager.shared.isSignedIn {
-                                    appLogger.warning("Clearing keychain due to loginError while signed out")
-                                    whereWeAre.deleteKeyChainPasword()
+                                    // Only clear keychain for auth-related failures, not network errors
+                                    let isAuthFailure = errMsg.lowercased().contains("password") ||
+                                                       errMsg.lowercased().contains("incorrect") ||
+                                                       errMsg.lowercased().contains("unauthorized") ||
+                                                       errMsg.lowercased().contains("failed to load data")
+                                    if isAuthFailure {
+                                        appLogger.warning("Clearing keychain due to auth failure: \(errMsg)")
+                                        whereWeAre.deleteKeyChainPasword()
+                                    } else {
+                                        appLogger.warning("Not clearing keychain for transient error: \(errMsg)")
+                                    }
                                 }
                             }
                         }

--- a/iOS/FluxHausApp.swift
+++ b/iOS/FluxHausApp.swift
@@ -181,16 +181,15 @@ struct FluxHausApp: App {
                                 let isSignedIn = AuthManager.shared.isSignedIn
                                 appLogger.warning("loginError: \(errMsg), isSignedIn=\(isSignedIn)")
                                 if !AuthManager.shared.isSignedIn {
-                                    // Only clear keychain for auth-related failures, not network errors
+                                    // Only clear keychain for actual auth failures
                                     let isAuthFailure = errMsg.lowercased().contains("password") ||
                                                        errMsg.lowercased().contains("incorrect") ||
-                                                       errMsg.lowercased().contains("unauthorized") ||
-                                                       errMsg.lowercased().contains("failed to load data")
+                                                       errMsg.lowercased().contains("unauthorized")
                                     if isAuthFailure {
                                         appLogger.warning("Clearing keychain due to auth failure: \(errMsg)")
                                         whereWeAre.deleteKeyChainPasword()
                                     } else {
-                                        appLogger.warning("Not clearing keychain for transient error: \(errMsg)")
+                                        appLogger.warning("Not clearing keychain for: \(errMsg)")
                                     }
                                 }
                             }

--- a/iOS/FluxHausApp.swift
+++ b/iOS/FluxHausApp.swift
@@ -181,11 +181,7 @@ struct FluxHausApp: App {
                                 let isSignedIn = AuthManager.shared.isSignedIn
                                 appLogger.warning("loginError: \(errMsg), isSignedIn=\(isSignedIn)")
                                 if !AuthManager.shared.isSignedIn {
-                                    // Only clear keychain for actual auth failures
-                                    let isAuthFailure = errMsg.lowercased().contains("password") ||
-                                                       errMsg.lowercased().contains("incorrect") ||
-                                                       errMsg.lowercased().contains("unauthorized")
-                                    if isAuthFailure {
+                                    if isAuthFailureMessage(errMsg) {
                                         appLogger.warning("Clearing keychain due to auth failure: \(errMsg)")
                                         whereWeAre.deleteKeyChainPasword()
                                     } else {

--- a/macOS/MacApp.swift
+++ b/macOS/MacApp.swift
@@ -526,8 +526,16 @@ struct MacApp: App {
             }
         }
         if (object.userInfo?["loginError"]) != nil {
+            let errMsg = object.userInfo?["loginError"] as? String ?? "unknown"
             if !AuthManager.shared.isSignedIn {
-                whereWeAre.deleteKeyChainPasword()
+                // Only clear keychain for auth-related failures, not network errors
+                let isAuthFailure = errMsg.lowercased().contains("password") ||
+                                   errMsg.lowercased().contains("incorrect") ||
+                                   errMsg.lowercased().contains("unauthorized") ||
+                                   errMsg.lowercased().contains("failed to load data")
+                if isAuthFailure {
+                    whereWeAre.deleteKeyChainPasword()
+                }
             }
         }
     }

--- a/macOS/MacApp.swift
+++ b/macOS/MacApp.swift
@@ -528,11 +528,7 @@ struct MacApp: App {
         if (object.userInfo?["loginError"]) != nil {
             let errMsg = object.userInfo?["loginError"] as? String ?? "unknown"
             if !AuthManager.shared.isSignedIn {
-                // Only clear keychain for actual auth failures
-                let isAuthFailure = errMsg.lowercased().contains("password") ||
-                                   errMsg.lowercased().contains("incorrect") ||
-                                   errMsg.lowercased().contains("unauthorized")
-                if isAuthFailure {
+                if isAuthFailureMessage(errMsg) {
                     whereWeAre.deleteKeyChainPasword()
                 }
             }

--- a/macOS/MacApp.swift
+++ b/macOS/MacApp.swift
@@ -528,11 +528,10 @@ struct MacApp: App {
         if (object.userInfo?["loginError"]) != nil {
             let errMsg = object.userInfo?["loginError"] as? String ?? "unknown"
             if !AuthManager.shared.isSignedIn {
-                // Only clear keychain for auth-related failures, not network errors
+                // Only clear keychain for actual auth failures
                 let isAuthFailure = errMsg.lowercased().contains("password") ||
                                    errMsg.lowercased().contains("incorrect") ||
-                                   errMsg.lowercased().contains("unauthorized") ||
-                                   errMsg.lowercased().contains("failed to load data")
+                                   errMsg.lowercased().contains("unauthorized")
                 if isAuthFailure {
                     whereWeAre.deleteKeyChainPasword()
                 }


### PR DESCRIPTION
## Problem
Network errors were being treated the same as authentication failures. When transient network issues occurred (timeouts, connection failures), the app would clear the saved password, forcing users to re-login.

## Solution
- **Error Categorization**: Distinguish between transient network errors and auth failures
- **Retry Logic**: Automatically retry transient errors (up to 3 retries with exponential backoff: 0.5s, 1s, 2s)
- **Credential Preservation**: Only clear keychain on actual auth failures, never on network errors
- **Platform Updates**: Updated iOS, VisionOS, and macOS error handling

## Changes
- `QueryFlux.swift`: Added error detection and retry mechanism
- `iOS/FluxHausApp.swift`: Updated error handling to distinguish auth failures from network errors
- `VisionOS/VisionOSApp.swift`: Applied same error handling fixes
- `macOS/MacApp.swift`: Applied same error handling fixes
- `QueryFluxWidgetExtensions.swift`: Extracted widget formatting (code quality improvement)
- `FluxHaus.xcodeproj`: Updated version to 1.8.8

## Testing
- ✅ SwiftLint verification: 0 violations
- ✅ Code builds successfully
- ✅ Error handling preserves credentials on network issues
- ✅ Auth failures still properly clear credentials