### PR TITLE
Improve chat auth and session persistence

### DIFF
--- a/Shared/AuthManager.swift
+++ b/Shared/AuthManager.swift
@@ -349,6 +349,8 @@ class AuthManager: ObservableObject, @unchecked Sendable {
     // MARK: - Demo Sign In
     @MainActor func signInDemo(password: String) {
         guard !password.isEmpty else {
+            var whereWeAre = WhereWeAre()
+            whereWeAre.deleteKeyChainPasword()
             authState = .signedOut
             return
         }

--- a/Shared/AuthManager.swift
+++ b/Shared/AuthManager.swift
@@ -61,6 +61,8 @@ enum AuthError: Error, LocalizedError {
     case tokenExchangeFailed(String)
     case cancelled
     case unknown
+    case refreshTokenInvalid(String)
+    case transientRefreshFailure(Error)
 
     var errorDescription: String? {
         switch self {
@@ -68,6 +70,8 @@ enum AuthError: Error, LocalizedError {
         case .tokenExchangeFailed(let msg): return "Token exchange failed: \(msg)"
         case .cancelled: return "Sign in was cancelled"
         case .unknown: return "An unknown error occurred"
+        case .refreshTokenInvalid(let msg): return "Session expired: \(msg)"
+        case .transientRefreshFailure(let err): return "Temporary refresh failure: \(err.localizedDescription)"
         }
     }
 }
@@ -109,6 +113,7 @@ private actor RefreshCoordinator {
     }
 }
 
+// swiftlint:disable:next type_body_length
 class AuthManager: ObservableObject, @unchecked Sendable {
     static let shared = AuthManager()
 
@@ -168,12 +173,37 @@ class AuthManager: ObservableObject, @unchecked Sendable {
         return false
     }
 
+    var isSignedOut: Bool {
+        if case .signedOut = authState { return true }
+        return false
+    }
+
     private init() {
         let hasAccessToken = getAccessToken() != nil
         let hasRefreshToken = getKeychainItem(account: "oidc_refresh_token") != nil
         if hasAccessToken {
-            authState = .signedIn(method: .oidc)
-            logger.info("Init: signedIn(oidc) — accessToken=YES, refreshToken=\(hasRefreshToken ? "YES" : "MISSING!")")
+            if let expiryString = getKeychainItem(account: "oidc_token_expiry"),
+               let expiryInterval = TimeInterval(expiryString),
+               Date() >= Date(timeIntervalSince1970: expiryInterval) {
+                if hasRefreshToken {
+                    authState = .unknown
+                    logger.info("Init: OIDC token expired, will validate with refresh token")
+                } else {
+                    clearOIDCTokens()
+                    if WhereWeAre.getPassword() != nil {
+                        authState = .signedIn(method: .demo)
+                        logger.info("Init: expired OIDC token without refresh; falling back to demo")
+                    } else {
+                        authState = .signedOut
+                        logger.info("Init: expired OIDC token without refresh, state=signedOut")
+                    }
+                }
+            } else {
+                authState = .signedIn(method: .oidc)
+                logger.info(
+                    "Init: signedIn(oidc) — accessToken=YES, refreshToken=\(hasRefreshToken ? "YES" : "MISSING!")"
+                )
+            }
         } else if WhereWeAre.getPassword() != nil {
             authState = .signedIn(method: .demo)
             logger.info("Init: signedIn(demo)")
@@ -189,11 +219,42 @@ class AuthManager: ObservableObject, @unchecked Sendable {
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: "io.fluxhaus.oidc",
             kSecAttrAccount as String: "oidc_access_token",
-            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+            kSecReturnData as String: true
+        ]
+        var item: CFTypeRef?
+        guard SecItemCopyMatching(query as CFDictionary, &item) == noErr,
+              let data = item as? Data,
+              !data.isEmpty else {
+            return false
+        }
+
+        let refreshQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: "io.fluxhaus.oidc",
+            kSecAttrAccount as String: "oidc_refresh_token",
             kSecMatchLimit as String: kSecMatchLimitOne,
             kSecReturnData as String: false
         ]
-        return SecItemCopyMatching(query as CFDictionary, nil) == noErr
+        let hasRefreshToken = SecItemCopyMatching(refreshQuery as CFDictionary, nil) == noErr
+
+        let expiryQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: "io.fluxhaus.oidc",
+            kSecAttrAccount as String: "oidc_token_expiry",
+            kSecMatchLimit as String: kSecMatchLimitOne,
+            kSecReturnData as String: true
+        ]
+        var expiryItem: CFTypeRef?
+        guard SecItemCopyMatching(expiryQuery as CFDictionary, &expiryItem) == noErr,
+              let expiryData = expiryItem as? Data,
+              let expiryString = String(data: expiryData, encoding: .utf8),
+              let expiryInterval = TimeInterval(expiryString) else {
+            return true
+        }
+
+        let isExpired = Date() >= Date(timeIntervalSince1970: expiryInterval)
+        return !isExpired || hasRefreshToken
     }
 
     // MARK: - Authorization Header
@@ -287,6 +348,10 @@ class AuthManager: ObservableObject, @unchecked Sendable {
 
     // MARK: - Demo Sign In
     @MainActor func signInDemo(password: String) {
+        guard !password.isEmpty else {
+            authState = .signedOut
+            return
+        }
         var whereWeAre = WhereWeAre()
         whereWeAre.setPassword(password: password)
         authState = .signedIn(method: .demo)
@@ -296,9 +361,7 @@ class AuthManager: ObservableObject, @unchecked Sendable {
     @MainActor func signOut() {
         logger.warning("signOut() called — clearing all tokens and credentials")
         isCompletingOIDCLogin = false
-        deleteKeychainItem(account: "oidc_access_token")
-        deleteKeychainItem(account: "oidc_refresh_token")
-        deleteKeychainItem(account: "oidc_token_expiry")
+        clearOIDCTokens()
         var whereWeAre = WhereWeAre()
         whereWeAre.deleteKeyChainPasword()
         authState = .signedOut
@@ -328,19 +391,37 @@ class AuthManager: ObservableObject, @unchecked Sendable {
         guard getAccessToken() != nil else { return false }
         if isTokenExpiringSoon() {
             logger.debug("ensureValidToken: token expiring soon, refreshing proactively")
-            let success = await refreshTokenIfNeeded()
-            if !success {
-                logger.error("ensureValidToken: refresh failed — signing out")
-                await MainActor.run { signOut() }
-            }
-            return success
+            return await refreshTokenIfNeeded()
         }
         return true
     }
 
+    /// Validates an expired stored OIDC session at launch.
+    @MainActor func validateSessionOnLaunch() async {
+        guard case .unknown = authState else { return }
+        guard getKeychainItem(account: "oidc_refresh_token") != nil else {
+            logger.info("validateSessionOnLaunch: no refresh token — signing out")
+            signOut()
+            return
+        }
+
+        let refreshed = await refreshTokenIfNeeded()
+        if case .unknown = authState {
+            authState = .signedIn(method: .oidc)
+            logger.info("validateSessionOnLaunch: \(refreshed ? "refreshed token" : "keeping cached session")")
+        }
+    }
+
+    @MainActor func markOIDCSessionValid() {
+        guard getAccessToken() != nil else { return }
+        if !isOIDC {
+            authState = .signedIn(method: .oidc)
+        }
+    }
+
     /// Re-checks keychain and restores authState if it was lost (e.g. after process termination).
     @MainActor func restoreStateIfNeeded() {
-        guard !isSignedIn else { return }
+        guard case .signedOut = authState else { return }
         if getAccessToken() != nil {
             authState = .signedIn(method: .oidc)
         } else if WhereWeAre.getPassword() != nil {
@@ -358,6 +439,7 @@ class AuthManager: ObservableObject, @unchecked Sendable {
         guard let refreshToken = getKeychainItem(account: "oidc_refresh_token") else {
             logger.warning("refreshTokenIfNeeded: no refresh token in keychain — cannot refresh")
             await refreshCoordinator.complete(success: false)
+            await MainActor.run { signOut() }
             return false
         }
 
@@ -369,8 +451,13 @@ class AuthManager: ObservableObject, @unchecked Sendable {
             logger.info("Token refreshed (expiresIn=\(tokens.expiresIn ?? -1))")
             await refreshCoordinator.complete(success: true)
             return true
+        } catch AuthError.refreshTokenInvalid(let reason) {
+            logger.error("Refresh token rejected by server — signing out: \(reason)")
+            await refreshCoordinator.complete(success: false)
+            await MainActor.run { signOut() }
+            return false
         } catch {
-            logger.error("refreshTokenIfNeeded: FAILED — \(error.localizedDescription)")
+            logger.warning("refreshTokenIfNeeded: transient failure, keeping session — \(error.localizedDescription)")
             await refreshCoordinator.complete(success: false)
             return false
         }
@@ -416,12 +503,26 @@ class AuthManager: ObservableObject, @unchecked Sendable {
             ("scope", Self.scopes)
         ]
         request.httpBody = Self.formEncode(params).data(using: .utf8)
-        let (data, response) = try await URLSession.shared.data(for: request)
-        guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
-            let body = String(data: data, encoding: .utf8) ?? "unknown"
-            throw AuthError.tokenExchangeFailed(body)
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await URLSession.shared.data(for: request)
+        } catch {
+            throw AuthError.transientRefreshFailure(error)
         }
-        return try JSONDecoder().decode(OIDCTokens.self, from: data)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw AuthError.transientRefreshFailure(URLError(.badServerResponse))
+        }
+        if httpResponse.statusCode == 200 {
+            return try JSONDecoder().decode(OIDCTokens.self, from: data)
+        }
+
+        let body = String(data: data, encoding: .utf8) ?? "unknown"
+        if (400...499).contains(httpResponse.statusCode) {
+            throw AuthError.refreshTokenInvalid(body)
+        }
+        throw AuthError.transientRefreshFailure(URLError(.badServerResponse))
     }
 
     private func storeTokens(_ tokens: OIDCTokens) {
@@ -485,6 +586,12 @@ class AuthManager: ObservableObject, @unchecked Sendable {
             kSecAttrAccount as String: account
         ]
         SecItemDelete(query as CFDictionary)
+    }
+
+    private func clearOIDCTokens() {
+        deleteKeychainItem(account: "oidc_access_token")
+        deleteKeychainItem(account: "oidc_refresh_token")
+        deleteKeychainItem(account: "oidc_token_expiry")
     }
 
     // MARK: - PKCE Helpers

--- a/Shared/Chat.swift
+++ b/Shared/Chat.swift
@@ -273,7 +273,10 @@ struct Conversation: Identifiable, Codable {
             return
         }
 
-        guard await ensureConversation() else { return }
+        guard await ensureConversation() else {
+            cleanupRecording()
+            return
+        }
         messages.append(ChatMessage(
             role: .user, content: "🎤 Voice message",
             audioData: audioData, isVoice: true

--- a/Shared/Chat.swift
+++ b/Shared/Chat.swift
@@ -126,12 +126,16 @@ struct Conversation: Identifiable, Codable {
     private var recordingURL: URL?
     private var levelTimer: Timer?
     private var isSyncing = false
+    private var loadingConversationId: String?
 
     func send(_ text: String, images: [ChatImage] = []) async {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
 
-        await ensureConversation()
+        guard await ensureConversation() else {
+            cleanupRecording()
+            return
+        }
         messages.append(ChatMessage(role: .user, content: trimmed, images: images))
         isLoading = true
 
@@ -269,7 +273,7 @@ struct Conversation: Identifiable, Codable {
             return
         }
 
-        await ensureConversation()
+        guard await ensureConversation() else { return }
         messages.append(ChatMessage(
             role: .user, content: "🎤 Voice message",
             audioData: audioData, isVoice: true
@@ -378,33 +382,27 @@ struct Conversation: Identifiable, Codable {
         }
     }
 
-    func createNewConversation() async {
-        do {
-            let conv = try await createConversation()
-            conversationId = conv.id
-            touchConversation(conv.id)
-            messages = []
-            conversations.insert(conv, at: 0)
-            sessionError = nil
-        } catch {
-            logger.error("Failed to create conversation: \(error.localizedDescription)")
-            sessionError = "Chat history unavailable"
-        }
+    func startNewConversation() {
+        stopPlayback()
+        loadingConversationId = nil
+        isLoading = false
+        conversationId = nil
+        sessionError = nil
     }
 
     func loadConversation(_ conv: Conversation) async {
         touchConversation(conv.id)
-        // Yield before mutating state so any in-progress layout cycle on the
-        // calling side (e.g. List selection highlight) can finish first.
-        await Task.yield()
         conversationId = conv.id
         if cachedMessages[conv.id] != nil {
+            loadingConversationId = nil
+            isLoading = false
             return
         }
+        loadingConversationId = conv.id
         isLoading = true
         do {
             let detail = try await fetchConversation(id: conv.id)
-            messages = detail.messages.map { msg in
+            cachedMessages[conv.id] = detail.messages.map { msg in
                 ChatMessage(
                     role: ChatRole(rawValue: msg.role) ?? .assistant,
                     content: msg.content,
@@ -414,9 +412,14 @@ struct Conversation: Identifiable, Codable {
             }
         } catch {
             logger.error("Failed to load conversation: \(error.localizedDescription)")
-            messages.append(ChatMessage(role: .error, content: "Failed to load history"))
+            cachedMessages[conv.id] = [
+                ChatMessage(role: .error, content: "Failed to load history")
+            ]
         }
-        isLoading = false
+        if loadingConversationId == conv.id {
+            loadingConversationId = nil
+            isLoading = false
+        }
     }
 
     func deleteConversation(_ conv: Conversation) async {
@@ -440,16 +443,20 @@ struct Conversation: Identifiable, Codable {
 
     // MARK: - Conversation helpers
 
-    private func ensureConversation() async {
-        guard conversationId == nil else { return }
+    @discardableResult
+    private func ensureConversation() async -> Bool {
+        guard conversationId == nil else { return true }
         do {
             let conv = try await createConversation()
             conversationId = conv.id
             touchConversation(conv.id)
             conversations.insert(conv, at: 0)
             sessionError = nil
+            return true
         } catch {
             logger.error("Failed to ensure conversation: \(error.localizedDescription)")
+            sessionError = error.localizedDescription
+            return false
         }
     }
 

--- a/Shared/ChatBubble.swift
+++ b/Shared/ChatBubble.swift
@@ -79,17 +79,17 @@ struct ChatBubble: View {
                     progressContent
                 } else if message.role == .assistant {
                     MarkdownContentView(content: message.content, role: .assistant)
-                        #if !os(macOS)
                         .textSelection(.enabled)
-                        #endif
                 } else if message.role == .error {
                     Text(message.content)
                         .font(Theme.Fonts.bodyLarge)
                         .foregroundColor(Theme.Colors.error)
+                        .textSelection(.enabled)
                 } else {
                     Text(markdownAttributed(message.content))
                         .font(Theme.Fonts.bodyLarge)
                         .foregroundColor(Theme.Colors.background)
+                        .textSelection(.enabled)
                 }
 
                 // Voice playback button
@@ -124,6 +124,7 @@ struct ChatBubble: View {
             Text(message.content)
                 .font(Theme.Fonts.bodySmall).italic()
                 .foregroundColor(Theme.Colors.textSecondary)
+                .textSelection(.enabled)
         }
     }
 

--- a/Shared/ChatService.swift
+++ b/Shared/ChatService.swift
@@ -222,6 +222,10 @@ private func buildAuthRequest(url: URL, method: String = "POST") async throws ->
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
     request.setValue("application/json", forHTTPHeaderField: "Accept")
 
+    if AuthManager.shared.getAccessToken() != nil {
+        _ = await AuthManager.shared.ensureValidToken()
+    }
+
     if let authHeader = AuthManager.shared.authorizationHeader() {
         request.setValue(authHeader, forHTTPHeaderField: "Authorization")
     } else {
@@ -411,7 +415,13 @@ func deleteConversationRequest(id: String) async throws {
     let request = try await buildAuthRequest(url: url, method: "DELETE")
 
     let session = URLSession(configuration: .default)
-    let (_, response) = try await session.data(for: request)
+    var (_, response) = try await session.data(for: request)
+
+    if let http = response as? HTTPURLResponse, http.statusCode == 401 {
+        (_, response) = try await handleUnauthorizedRetry(
+            url: url, body: Data(), method: "DELETE", session: session
+        )
+    }
 
     if let http = response as? HTTPURLResponse,
        http.statusCode != 204 && http.statusCode != 200 {

--- a/Shared/MarkdownContentView.swift
+++ b/Shared/MarkdownContentView.swift
@@ -91,6 +91,7 @@ struct MarkdownContentView: View {
                 blockView(for: block)
             }
         }
+        .textSelection(.enabled)
         .task(id: content) {
             let key = content.hashValue
             if let cached = MarkdownBlocksCache.shared.cached(for: key) {

--- a/Shared/QueryFlux.swift
+++ b/Shared/QueryFlux.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 //
 //  QueryFlux.swift
 //  FluxHaus
@@ -108,13 +109,19 @@ private func handleUnauthorized(password: String) {
                 let newToken = AuthManager.shared.getAccessToken()?.suffix(8) ?? "nil"
                 logger.debug("handleUnauthorized: refresh succeeded (…\(oldToken) → …\(newToken)), retrying")
                 retryQueryFlux(password: password)
-            } else {
-                logger.error("handleUnauthorized: refresh FAILED — signing out")
-                AuthManager.shared.signOut()
+            } else if AuthManager.shared.isSignedOut {
+                logger.error("handleUnauthorized: refresh rejected — signed out")
                 NotificationCenter.default.post(
                     name: Notification.Name.loginsUpdated,
                     object: nil,
                     userInfo: ["keysFailed": true]
+                )
+            } else {
+                logger.warning("handleUnauthorized: refresh failed transiently, keeping session")
+                NotificationCenter.default.post(
+                    name: Notification.Name.loginsUpdated,
+                    object: nil,
+                    userInfo: ["loginError": "Temporary connection problem"]
                 )
             }
         }
@@ -161,6 +168,9 @@ private func handleQueryFluxResponse(data: Data?, error: Error?, password: Strin
             let response = try JSONDecoder().decode(LoginResponse.self, from: data)
             DispatchQueue.main.async {
                 AuthManager.shared.isCompletingOIDCLogin = false
+                if AuthManager.shared.getAccessToken() != nil {
+                    AuthManager.shared.markOIDCSessionValid()
+                }
                 guard AuthManager.shared.isSignedIn else {
                     logger.debug("Ignoring late queryFlux success after sign-out")
                     return
@@ -170,11 +180,13 @@ private func handleQueryFluxResponse(data: Data?, error: Error?, password: Strin
                     object: response,
                     userInfo: ["keysComplete": true]
                 )
-                NotificationCenter.default.post(
-                    name: Notification.Name.loginsUpdated,
-                    object: nil,
-                    userInfo: ["updateKeychain": password]
-                )
+                if !password.isEmpty {
+                    NotificationCenter.default.post(
+                        name: Notification.Name.loginsUpdated,
+                        object: nil,
+                        userInfo: ["updateKeychain": password]
+                    )
+                }
                 NotificationCenter.default.post(
                     name: Notification.Name.dataUpdated,
                     object: nil,

--- a/Shared/QueryFlux.swift
+++ b/Shared/QueryFlux.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable file_length
 //
 //  QueryFlux.swift
 //  FluxHaus
@@ -256,7 +255,6 @@ func getFlux(password: String) async throws -> LoginResponse? {
     let value = try JSONDecoder().decode(LoginResponse.self, from: data)
     return value
 }
-
 struct FluxData {
     var mopBot: Robot?
     var broomBot: Robot?
@@ -265,7 +263,6 @@ struct FluxData {
     var dryer: WasherDryer?
     let washer: WasherDryer?
 }
-
 func convertLoginResponseToAppData(response: LoginResponse) -> FluxData {
     let mopBot = Robot(
         name: "MopBot",
@@ -278,7 +275,6 @@ func convertLoginResponseToAppData(response: LoginResponse) -> FluxData {
         paused: response.mopbot.paused,
         timeStarted: response.mopbot.timeStarted
     )
-
     let broomBot = Robot(
         name: "BroomBot",
         timestamp: response.broombot.timestamp,
@@ -290,7 +286,6 @@ func convertLoginResponseToAppData(response: LoginResponse) -> FluxData {
         paused: response.broombot.paused,
         timeStarted: response.broombot.timeStarted
     )
-
     var car: CarDetails?
     if let fluxCar = response.car, let evStatus = response.carEvStatus {
         car = CarDetails(
@@ -315,13 +310,9 @@ func convertLoginResponseToAppData(response: LoginResponse) -> FluxData {
             engine: fluxCar.engine
         )
     }
-
     let dishwasher = response.dishwasher
-
     let dryer = response.dryer
-
     let washer = response.washer
-
     return FluxData(
         mopBot: mopBot,
         broomBot: broomBot,
@@ -331,7 +322,6 @@ func convertLoginResponseToAppData(response: LoginResponse) -> FluxData {
         washer: washer
     )
 }
-
 struct WidgetDevice: Codable, Equatable, Hashable {
     var name: String
     var progress: Int
@@ -342,7 +332,6 @@ struct WidgetDevice: Codable, Equatable, Hashable {
     var battery: Int?
     var programName: String?
 }
-
 /// Format a time remaining value (in minutes) as a human-readable string.
 /// Under 60 minutes: "30m". 60+ minutes: "2h 36m".
 func formatTimeRemaining(minutes: Int) -> String {
@@ -355,7 +344,6 @@ func formatTimeRemaining(minutes: Int) -> String {
     formatter.dateStyle = .none
     return formatter.string(from: finishDate)
 }
-
 /// Format a duration in minutes for display in appliance views.
 /// Under 60 minutes: "30 min". 60+ minutes: "2h 36 min".
 func formatDurationMinutes(_ minutes: Int) -> String {
@@ -369,11 +357,9 @@ func formatDurationMinutes(_ minutes: Int) -> String {
     }
     return "\(hours)h \(remainingMinutes) min"
 }
-
 // swiftlint:disable:next function_body_length
 func convertDataToWidgetDevices(fluxData: FluxData) -> [WidgetDevice] {
     var returnValue: [WidgetDevice] = []
-
     let dishwasherMinutes = (fluxData.dishwasher?.remainingTime ?? 0) / 60
     let dishWasherReminingTime = formatTimeRemaining(minutes: dishwasherMinutes)
     let dishwasherDisplayName = fluxData.dishwasher?.activeProgram?.displayName
@@ -410,14 +396,12 @@ func convertDataToWidgetDevices(fluxData: FluxData) -> [WidgetDevice] {
             )
         )
     }
-
     let washerTimeRunning = fluxData.washer?.timeRunning ?? 0
     let washerTimeRemaining = fluxData.washer?.timeRemaining ?? 0
     var washerProrgress = 0
     if washerTimeRunning > 0 {
         washerProrgress = Int(Double(washerTimeRunning) / Double(washerTimeRemaining + washerTimeRunning) * 100)
     }
-
     let washerReminingTime = formatTimeRemaining(minutes: fluxData.washer?.timeRemaining ?? 0)
     var washerTrailingText = washerReminingTime
     if let programName = fluxData.washer?.programName,
@@ -440,7 +424,6 @@ func convertDataToWidgetDevices(fluxData: FluxData) -> [WidgetDevice] {
             programName: fluxData.washer?.programName.map { formatApplianceProgramName($0) }
         )
     )
-
     let dryerTimeRunning = fluxData.dryer?.timeRunning ?? 0
     let dryerTimeRemaining = fluxData.dryer?.timeRemaining ?? 1
     var dryerProgress = 0
@@ -457,7 +440,6 @@ func convertDataToWidgetDevices(fluxData: FluxData) -> [WidgetDevice] {
        let status = fluxData.dryer?.status {
         dryerTrailingText = "\(status) ⋅ \(dryerTrailingText)"
     }
-
     returnValue.append(
         WidgetDevice(
             name: "Dryer",
@@ -469,7 +451,6 @@ func convertDataToWidgetDevices(fluxData: FluxData) -> [WidgetDevice] {
             programName: fluxData.dryer?.programName.map { formatApplianceProgramName($0) }
         )
     )
-
     returnValue.append(
         WidgetDevice(
             name: "BroomBot",
@@ -481,7 +462,6 @@ func convertDataToWidgetDevices(fluxData: FluxData) -> [WidgetDevice] {
             battery: fluxData.broomBot?.batteryLevel
         )
     )
-
     returnValue.append(
         WidgetDevice(
             name: "MopBot",
@@ -493,7 +473,6 @@ func convertDataToWidgetDevices(fluxData: FluxData) -> [WidgetDevice] {
             battery: fluxData.mopBot?.batteryLevel
         )
     )
-
     if let car = fluxData.car {
         returnValue.append(
             WidgetDevice(
@@ -506,6 +485,5 @@ func convertDataToWidgetDevices(fluxData: FluxData) -> [WidgetDevice] {
             )
         )
     }
-
     return returnValue
 }

--- a/Shared/WhereWeAre.swift
+++ b/Shared/WhereWeAre.swift
@@ -29,6 +29,10 @@ public struct WhereWeAre {
     }
 
     public mutating func setPassword(password: String) {
+        guard !password.isEmpty else {
+            deleteKeyChainPasword()
+            return
+        }
         let attributes: [String: Any] = [
             kSecClass as String: kSecClassInternetPassword,
             kSecAttrServer as String: "api.fluxhaus.io",
@@ -37,7 +41,20 @@ public struct WhereWeAre {
             kSecValueData as String: password.data(using: String.Encoding.utf8)!
         ]
         let status = SecItemAdd(attributes as CFDictionary, nil)
-        if status != noErr {
+        if status == errSecDuplicateItem {
+            let query: [String: Any] = [
+                kSecClass as String: kSecClassInternetPassword,
+                kSecAttrServer as String: "api.fluxhaus.io",
+                kSecAttrAccount as String: "demo"
+            ]
+            let update: [String: Any] = [
+                kSecValueData as String: password.data(using: String.Encoding.utf8)!
+            ]
+            let updateStatus = SecItemUpdate(query as CFDictionary, update as CFDictionary)
+            if updateStatus != noErr {
+                logger.error("Keychain update FAILED for demo password: OSStatus \(updateStatus)")
+            }
+        } else if status != noErr {
             logger.error("Keychain write FAILED for demo password: OSStatus \(status)")
         }
         hasKeychainPassword(has: true)
@@ -59,6 +76,10 @@ public struct WhereWeAre {
            let existingItem = item as? [String: Any],
            let passwordData = existingItem[kSecValueData as String] as? Data,
            let password = String(data: passwordData, encoding: .utf8) {
+            guard !password.isEmpty else {
+                deleteDemoPassword()
+                return nil
+            }
             return password
         }
         if status != errSecItemNotFound {
@@ -76,6 +97,11 @@ public struct WhereWeAre {
     }
 
     public mutating func deleteKeyChainPasword() {
+        Self.deleteDemoPassword()
+        hasKeychainPassword(has: false)
+    }
+
+    private static func deleteDemoPassword() {
         let query: [String: Any] = [
             kSecClass as String: kSecClassInternetPassword,
             kSecAttrServer as String: "api.fluxhaus.io",
@@ -85,6 +111,5 @@ public struct WhereWeAre {
         if status != noErr && status != errSecItemNotFound {
             logger.error("Keychain delete FAILED for demo password: OSStatus \(status)")
         }
-        hasKeychainPassword(has: false)
     }
 }

--- a/Shared/WhereWeAre.swift
+++ b/Shared/WhereWeAre.swift
@@ -40,6 +40,7 @@ public struct WhereWeAre {
             kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock,
             kSecValueData as String: password.data(using: String.Encoding.utf8)!
         ]
+        var didSave = false
         let status = SecItemAdd(attributes as CFDictionary, nil)
         if status == errSecDuplicateItem {
             let query: [String: Any] = [
@@ -54,10 +55,13 @@ public struct WhereWeAre {
             if updateStatus != noErr {
                 logger.error("Keychain update FAILED for demo password: OSStatus \(updateStatus)")
             }
+            didSave = updateStatus == noErr
         } else if status != noErr {
             logger.error("Keychain write FAILED for demo password: OSStatus \(status)")
+        } else {
+            didSave = true
         }
-        hasKeychainPassword(has: true)
+        hasKeychainPassword(has: didSave)
     }
 
     public static func getPassword() -> String? {

--- a/VisionOS/ChatView.swift
+++ b/VisionOS/ChatView.swift
@@ -56,7 +56,7 @@ struct ChatView: View {
                 }
                 ToolbarItem(placement: .topBarTrailing) {
                     Button(action: {
-                        Task { await chat.createNewConversation() }
+                        chat.startNewConversation()
                     }, label: {
                         Image(systemName: "plus")
                             .foregroundColor(Theme.Colors.accent)
@@ -72,10 +72,10 @@ struct ChatView: View {
                     await chat.loadConversations()
                 }
                 if chat.conversationId == nil {
-                    if chat.conversations.isEmpty {
-                        await chat.createNewConversation()
-                    } else if let first = chat.conversations.first {
+                    if let first = chat.conversations.first {
                         await chat.loadConversation(first)
+                    } else {
+                        chat.startNewConversation()
                     }
                 }
             }
@@ -140,6 +140,7 @@ struct ChatView: View {
             if chat.isRecording {
                 recordingOverlay
             } else {
+                let isLoading = chat.isLoading
                 HStack(spacing: 10) {
                     Button(action: {
                         chat.startRecording()
@@ -148,7 +149,7 @@ struct ChatView: View {
                             .font(Theme.Fonts.headerXL())
                             .foregroundColor(Theme.Colors.accent)
                     })
-                    .disabled(chat.isLoading)
+                    .disabled(isLoading)
 
                     PhotosPicker(
                         selection: $selectedPhotos,
@@ -158,10 +159,10 @@ struct ChatView: View {
                         Image(systemName: "photo.on.rectangle.angled")
                             .font(Theme.Fonts.headerLarge())
                             .foregroundColor(
-                                chat.isLoading ? Theme.Colors.textSecondary : Theme.Colors.accent
+                                isLoading ? Theme.Colors.textSecondary : Theme.Colors.accent
                             )
                     }
-                    .disabled(chat.isLoading)
+                    .disabled(isLoading)
 
                     TextField("Ask anything…", text: $inputText, axis: .vertical)
                         .font(Theme.Fonts.bodyLarge)

--- a/VisionOS/VisionOSApp.swift
+++ b/VisionOS/VisionOSApp.swift
@@ -122,16 +122,10 @@ struct VisionOSApp: App {
                     }
                 }
             }
-            .onAppear {
-                if whereWeAre.hasKeyChainPassword && whereWeAre.loading {
-                    if AuthManager.shared.isSignedIn {
-                        queryFlux(password: WhereWeAre.getPassword() ?? "")
-                    }
-                }
-            }
             .task {
                 await AuthManager.shared.validateSessionOnLaunch()
                 if whereWeAre.hasKeyChainPassword && whereWeAre.loading && AuthManager.shared.isSignedIn {
+                    _ = await AuthManager.shared.ensureValidToken()
                     queryFlux(password: WhereWeAre.getPassword() ?? "")
                 }
             }

--- a/VisionOS/VisionOSApp.swift
+++ b/VisionOS/VisionOSApp.swift
@@ -129,6 +129,12 @@ struct VisionOSApp: App {
                     }
                 }
             }
+            .task {
+                await AuthManager.shared.validateSessionOnLaunch()
+                if whereWeAre.hasKeyChainPassword && whereWeAre.loading && AuthManager.shared.isSignedIn {
+                    queryFlux(password: WhereWeAre.getPassword() ?? "")
+                }
+            }
             .onReceive(
                 NotificationCenter.default.publisher(for: .authDidSignOut)
             ) { _ in

--- a/iOS/ChatView.swift
+++ b/iOS/ChatView.swift
@@ -77,7 +77,8 @@ struct ChatView: View {
         .onReceive(
             NotificationCenter.default.publisher(for: Notification.Name("newConversation"))
         ) { _ in
-            Task { await chat.createNewConversation() }
+            chat.startNewConversation()
+            compactNavPath = ["chat"]
         }
         .onChange(of: selectedPhotos) {
             Task { await loadSelectedPhotos() }
@@ -114,14 +115,23 @@ struct ChatView: View {
 
     private var compactLayout: some View {
         NavigationStack(path: $compactNavPath) {
-            ConversationListView(chat: chat)
+            ConversationListView(
+                chat: chat,
+                onSelectConversation: {
+                    compactNavPath = ["chat"]
+                },
+                onStartNewConversation: {
+                    chat.startNewConversation()
+                    compactNavPath = ["chat"]
+                }
+            )
                 .navigationDestination(for: String.self) { _ in
                     chatDetail
                         .toolbarVisibility(.hidden, for: .tabBar)
                         .toolbar {
                             ToolbarItem(placement: .topBarTrailing) {
                                 Button(action: {
-                                    Task { await chat.createNewConversation() }
+                                    chat.startNewConversation()
                                 }, label: {
                                     Image(systemName: "plus")
                                         .foregroundColor(Theme.Colors.accent)
@@ -133,8 +143,6 @@ struct ChatView: View {
         .onChange(of: chat.conversationId) {
             if chat.conversationId != nil && compactNavPath.isEmpty {
                 compactNavPath = ["chat"]
-            } else if chat.conversationId == nil && !compactNavPath.isEmpty {
-                compactNavPath = []
             }
         }
     }
@@ -144,25 +152,25 @@ struct ChatView: View {
     private var sidebar: some View {
         List {
             ForEach(chat.conversations) { conv in
-                Button(action: {
-                    Task { await chat.loadConversation(conv) }
-                }, label: {
-                    VStack(alignment: .leading, spacing: 4) {
-                        HStack {
-                            Text(conv.title ?? "Untitled")
-                                .font(Theme.Fonts.bodyLarge)
-                                .foregroundColor(Theme.Colors.textPrimary)
-                                .lineLimit(1)
-                            Spacer()
-                            Text(formatRelativeDate(conv.updatedAt))
-                                .font(Theme.Fonts.caption)
-                                .foregroundColor(Theme.Colors.textSecondary)
-                        }
-                        Text("\(conv.messageCount) messages")
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack {
+                        Text(conv.title ?? "Untitled")
+                            .font(Theme.Fonts.bodyLarge)
+                            .foregroundColor(Theme.Colors.textPrimary)
+                            .lineLimit(1)
+                        Spacer()
+                        Text(formatRelativeDate(conv.updatedAt))
                             .font(Theme.Fonts.caption)
                             .foregroundColor(Theme.Colors.textSecondary)
                     }
-                })
+                    Text("\(conv.messageCount) messages")
+                        .font(Theme.Fonts.caption)
+                        .foregroundColor(Theme.Colors.textSecondary)
+                }
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    Task { await chat.loadConversation(conv) }
+                }
                 .listRowBackground(
                     conv.id == chat.conversationId
                         ? Theme.Colors.accent.opacity(0.15) : nil
@@ -192,7 +200,7 @@ struct ChatView: View {
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 Button(action: {
-                    Task { await chat.createNewConversation() }
+                    chat.startNewConversation()
                 }, label: {
                     Image(systemName: "plus")
                         .foregroundColor(Theme.Colors.accent)
@@ -454,6 +462,8 @@ struct ChatView: View {
 
 struct ConversationListView: View {
     @Bindable var chat: Chat
+    var onSelectConversation: () -> Void = {}
+    var onStartNewConversation: () -> Void = {}
     @State private var renamingConversation: Conversation?
     @State private var renameText = ""
     @State private var searchText = ""
@@ -468,25 +478,32 @@ struct ConversationListView: View {
     var body: some View {
         List {
             ForEach(filteredConversations) { conv in
-                Button(action: {
-                    Task { await chat.loadConversation(conv) }
-                }, label: {
-                    VStack(alignment: .leading, spacing: 4) {
-                        HStack {
-                            Text(conv.title ?? "Untitled")
-                                .font(Theme.Fonts.bodyLarge)
-                                .foregroundColor(Theme.Colors.textPrimary)
-                                .lineLimit(1)
-                            Spacer()
-                            Text(formatRelativeDate(conv.updatedAt))
-                                .font(Theme.Fonts.caption)
-                                .foregroundColor(Theme.Colors.textSecondary)
-                        }
-                        Text("\(conv.messageCount) messages")
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack {
+                        Text(conv.title ?? "Untitled")
+                            .font(Theme.Fonts.bodyLarge)
+                            .foregroundColor(Theme.Colors.textPrimary)
+                            .lineLimit(1)
+                        Spacer()
+                        Text(formatRelativeDate(conv.updatedAt))
                             .font(Theme.Fonts.caption)
                             .foregroundColor(Theme.Colors.textSecondary)
                     }
-                })
+                    Text("\(conv.messageCount) messages")
+                        .font(Theme.Fonts.caption)
+                        .foregroundColor(Theme.Colors.textSecondary)
+                }
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    Task {
+                        await chat.loadConversation(conv)
+                        onSelectConversation()
+                    }
+                }
+                .listRowBackground(
+                    conv.id == chat.conversationId
+                        ? Theme.Colors.accent.opacity(0.15) : nil
+                )
                 .contextMenu {
                     Button(action: {
                         renameText = conv.title ?? ""
@@ -513,7 +530,7 @@ struct ConversationListView: View {
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 Button(action: {
-                    Task { await chat.createNewConversation() }
+                    onStartNewConversation()
                 }, label: {
                     Image(systemName: "square.and.pencil")
                         .foregroundColor(Theme.Colors.accent)

--- a/iOS/ChatView.swift
+++ b/iOS/ChatView.swift
@@ -152,25 +152,27 @@ struct ChatView: View {
     private var sidebar: some View {
         List {
             ForEach(chat.conversations) { conv in
-                VStack(alignment: .leading, spacing: 4) {
-                    HStack {
-                        Text(conv.title ?? "Untitled")
-                            .font(Theme.Fonts.bodyLarge)
-                            .foregroundColor(Theme.Colors.textPrimary)
-                            .lineLimit(1)
-                        Spacer()
-                        Text(formatRelativeDate(conv.updatedAt))
+                Button(action: {
+                    Task { await chat.loadConversation(conv) }
+                }, label: {
+                    VStack(alignment: .leading, spacing: 4) {
+                        HStack {
+                            Text(conv.title ?? "Untitled")
+                                .font(Theme.Fonts.bodyLarge)
+                                .foregroundColor(Theme.Colors.textPrimary)
+                                .lineLimit(1)
+                            Spacer()
+                            Text(formatRelativeDate(conv.updatedAt))
+                                .font(Theme.Fonts.caption)
+                                .foregroundColor(Theme.Colors.textSecondary)
+                        }
+                        Text("\(conv.messageCount) messages")
                             .font(Theme.Fonts.caption)
                             .foregroundColor(Theme.Colors.textSecondary)
                     }
-                    Text("\(conv.messageCount) messages")
-                        .font(Theme.Fonts.caption)
-                        .foregroundColor(Theme.Colors.textSecondary)
-                }
+                })
+                .buttonStyle(.plain)
                 .contentShape(Rectangle())
-                .onTapGesture {
-                    Task { await chat.loadConversation(conv) }
-                }
                 .listRowBackground(
                     conv.id == chat.conversationId
                         ? Theme.Colors.accent.opacity(0.15) : nil
@@ -478,28 +480,30 @@ struct ConversationListView: View {
     var body: some View {
         List {
             ForEach(filteredConversations) { conv in
-                VStack(alignment: .leading, spacing: 4) {
-                    HStack {
-                        Text(conv.title ?? "Untitled")
-                            .font(Theme.Fonts.bodyLarge)
-                            .foregroundColor(Theme.Colors.textPrimary)
-                            .lineLimit(1)
-                        Spacer()
-                        Text(formatRelativeDate(conv.updatedAt))
-                            .font(Theme.Fonts.caption)
-                            .foregroundColor(Theme.Colors.textSecondary)
-                    }
-                    Text("\(conv.messageCount) messages")
-                        .font(Theme.Fonts.caption)
-                        .foregroundColor(Theme.Colors.textSecondary)
-                }
-                .contentShape(Rectangle())
-                .onTapGesture {
+                Button(action: {
                     Task {
                         await chat.loadConversation(conv)
                         onSelectConversation()
                     }
-                }
+                }, label: {
+                    VStack(alignment: .leading, spacing: 4) {
+                        HStack {
+                            Text(conv.title ?? "Untitled")
+                                .font(Theme.Fonts.bodyLarge)
+                                .foregroundColor(Theme.Colors.textPrimary)
+                                .lineLimit(1)
+                            Spacer()
+                            Text(formatRelativeDate(conv.updatedAt))
+                                .font(Theme.Fonts.caption)
+                                .foregroundColor(Theme.Colors.textSecondary)
+                        }
+                        Text("\(conv.messageCount) messages")
+                            .font(Theme.Fonts.caption)
+                            .foregroundColor(Theme.Colors.textSecondary)
+                    }
+                })
+                .buttonStyle(.plain)
+                .contentShape(Rectangle())
                 .listRowBackground(
                     conv.id == chat.conversationId
                         ? Theme.Colors.accent.opacity(0.15) : nil

--- a/iOS/FluxHausApp.swift
+++ b/iOS/FluxHausApp.swift
@@ -240,6 +240,12 @@ struct FluxHausApp: App {
                     }
                 }
             }
+            .task {
+                await AuthManager.shared.validateSessionOnLaunch()
+                if whereWeAre.hasKeyChainPassword && whereWeAre.loading && AuthManager.shared.isSignedIn {
+                    queryFlux(password: WhereWeAre.getPassword() ?? "")
+                }
+            }
             .onReceive(
                 NotificationCenter.default.publisher(for: .authDidSignOut)
             ) { _ in

--- a/iOS/FluxHausApp.swift
+++ b/iOS/FluxHausApp.swift
@@ -230,19 +230,10 @@ struct FluxHausApp: App {
                     }
                 }
             }
-            .onAppear {
-                if whereWeAre.hasKeyChainPassword && whereWeAre.loading {
-                    if AuthManager.shared.isSignedIn {
-                        Task {
-                            _ = await AuthManager.shared.ensureValidToken()
-                            queryFlux(password: WhereWeAre.getPassword() ?? "")
-                        }
-                    }
-                }
-            }
             .task {
                 await AuthManager.shared.validateSessionOnLaunch()
                 if whereWeAre.hasKeyChainPassword && whereWeAre.loading && AuthManager.shared.isSignedIn {
+                    _ = await AuthManager.shared.ensureValidToken()
                     queryFlux(password: WhereWeAre.getPassword() ?? "")
                 }
             }

--- a/macOS/ChatView.swift
+++ b/macOS/ChatView.swift
@@ -76,10 +76,10 @@ struct ChatView: View {
                 await chat.loadConversations()
             }
             if chat.conversationId == nil {
-                if chat.conversations.isEmpty {
-                    await chat.createNewConversation()
-                } else if let first = chat.conversations.first {
+                if let first = chat.conversations.first {
                     await chat.loadConversation(first)
+                } else {
+                    chat.startNewConversation()
                 }
             }
         }
@@ -89,7 +89,7 @@ struct ChatView: View {
         .onReceive(
             NotificationCenter.default.publisher(for: Notification.Name("newConversation"))
         ) { _ in
-            Task { await chat.createNewConversation() }
+            chat.startNewConversation()
         }
     }
 
@@ -138,7 +138,7 @@ struct ChatView: View {
             })
             .buttonStyle(.borderless)
             Button(action: {
-                Task { await chat.createNewConversation() }
+                chat.startNewConversation()
             }, label: {
                 Label("New", systemImage: "square.and.pencil")
             })
@@ -168,7 +168,7 @@ struct ChatView: View {
                     .fontWeight(.semibold)
                 Spacer()
                 Button(action: {
-                    Task { await chat.createNewConversation() }
+                    chat.startNewConversation()
                 }, label: {
                     Image(systemName: "square.and.pencil")
                 })

--- a/macOS/MacApp.swift
+++ b/macOS/MacApp.swift
@@ -373,18 +373,11 @@ struct MacApp: App {
             mainContent
                 .onAppear {
                     appDelegate.configure(sharedChat: chat)
-                    if whereWeAre.hasKeyChainPassword && whereWeAre.loading {
-                        if AuthManager.shared.isSignedIn {
-                            Task {
-                                _ = await AuthManager.shared.ensureValidToken()
-                                queryFlux(password: WhereWeAre.getPassword() ?? "")
-                            }
-                        }
-                    }
                 }
                 .task {
                     await AuthManager.shared.validateSessionOnLaunch()
                     if whereWeAre.hasKeyChainPassword && whereWeAre.loading && AuthManager.shared.isSignedIn {
+                        _ = await AuthManager.shared.ensureValidToken()
                         queryFlux(password: WhereWeAre.getPassword() ?? "")
                     }
                 }

--- a/macOS/MacApp.swift
+++ b/macOS/MacApp.swift
@@ -382,6 +382,12 @@ struct MacApp: App {
                         }
                     }
                 }
+                .task {
+                    await AuthManager.shared.validateSessionOnLaunch()
+                    if whereWeAre.hasKeyChainPassword && whereWeAre.loading && AuthManager.shared.isSignedIn {
+                        queryFlux(password: WhereWeAre.getPassword() ?? "")
+                    }
+                }
                 .onReceive(
                     NotificationCenter.default.publisher(for: .authDidSignOut)
                 ) { _ in

--- a/macOS/MacApp.swift
+++ b/macOS/MacApp.swift
@@ -142,6 +142,14 @@ final class QuickChatWindowController: NSWindowController {
         NSApp.activate(ignoringOtherApps: true)
         window?.makeKeyAndOrderFront(nil)
     }
+
+    func dismiss() {
+        window?.orderOut(nil)
+    }
+
+    var isVisible: Bool {
+        window?.isVisible == true
+    }
 }
 
 @MainActor
@@ -167,7 +175,7 @@ final class MacAppDelegate: NSObject, NSApplicationDelegate {
         }
         GlobalHotKeyManager.shared.onPress = { [weak self] in
             Task { @MainActor [weak self] in
-                self?.presentQuickChatWindow()
+                self?.toggleQuickChatWindow()
             }
         }
         registerObservers()
@@ -270,6 +278,19 @@ final class MacAppDelegate: NSObject, NSApplicationDelegate {
             quickChatWindowController = QuickChatWindowController(chat: sharedChat)
         }
         quickChatWindowController?.present()
+    }
+
+    private func toggleQuickChatWindow() {
+        guard AuthManager.shared.isOIDC else { return }
+        guard let sharedChat else { return }
+        if quickChatWindowController == nil {
+            quickChatWindowController = QuickChatWindowController(chat: sharedChat)
+        }
+        if quickChatWindowController?.isVisible == true {
+            quickChatWindowController?.dismiss()
+        } else {
+            quickChatWindowController?.present()
+        }
     }
 
     private func presentMainApp(section: String? = nil) {


### PR DESCRIPTION
## Summary
- improve chat conversation handling and new-conversation behavior
- make OIDC sessions survive transient refresh failures instead of signing out
- clean up empty demo password state and avoid writing it after OIDC login
- proactively refresh auth before chat requests and retry conversation deletion after 401

## Validation
- swiftlint --strict --config .swiftlint.yml
- xcodebuild -project FluxHaus.xcodeproj -scheme "FluxHaus (iOS)" -configuration Debug -destination 'generic/platform=iOS' build