### PR TITLE
Modernize Swift concurrency and observation

### DIFF
--- a/Shared/Api.swift
+++ b/Shared/Api.swift
@@ -8,8 +8,8 @@
 import Foundation
 
 @MainActor
-class Api: ObservableObject {
-    @Published var response: LoginResponse?
+@Observable class Api {
+    var response: LoginResponse?
 
     func setApiResponse(apiResponse: LoginResponse) {
         self.response = apiResponse

--- a/Shared/AppliancesDetailView.swift
+++ b/Shared/AppliancesDetailView.swift
@@ -5,9 +5,9 @@
 import SwiftUI
 
 struct AppliancesDetailView: View {
-    @ObservedObject var hconn: HomeConnect
-    @ObservedObject var miele: Miele
-    @ObservedObject var apiResponse: Api
+    var hconn: HomeConnect
+    var miele: Miele
+    var apiResponse: Api
     var robots: Robots
     @State private var showBroomBotSheet = false
     @State private var showMopBotSheet = false

--- a/Shared/AppliancesView.swift
+++ b/Shared/AppliancesView.swift
@@ -9,9 +9,9 @@ import SwiftUI
 
 struct Appliances: View {
     var fluxHausConsts: FluxHausConsts
-    @ObservedObject var hconn: HomeConnect
-    @ObservedObject var miele: Miele
-    @ObservedObject var apiResponse: Api
+    var hconn: HomeConnect
+    var miele: Miele
+    var apiResponse: Api
 
     var robots: Robots
     var battery: Battery

--- a/Shared/AuthManager.swift
+++ b/Shared/AuthManager.swift
@@ -114,7 +114,7 @@ private actor RefreshCoordinator {
 }
 
 // swiftlint:disable:next type_body_length
-class AuthManager: ObservableObject, @unchecked Sendable {
+@Observable class AuthManager: @unchecked Sendable {
     static let shared = AuthManager()
 
     // OIDC configuration — set OIDCClientID and OIDCIssuerBase in Info.plist
@@ -150,11 +150,11 @@ class AuthManager: ObservableObject, @unchecked Sendable {
         case demo
     }
 
-    @Published var authState: AuthState = .unknown
+    var authState: AuthState = .unknown
 
     /// True while an OIDC sign-in is completing (exchange → first API call).
     /// Used to suppress duplicate queryFlux triggered by scenePhase changes.
-    @Published var isCompletingOIDCLogin = false
+    var isCompletingOIDCLogin = false
 
     // Keep strong references to prevent deallocation during auth
     private var currentAuthSession: ASWebAuthenticationSession?

--- a/Shared/Battery.swift
+++ b/Shared/Battery.swift
@@ -25,13 +25,9 @@ enum Model {
     var model = Model.iPhone
 
     init() {
-        DispatchQueue.main.async {
-            UIDevice.current.isBatteryMonitoringEnabled = true
-            print(UIDevice.current.isBatteryMonitoringEnabled)
-            print(UIDevice.current.batteryLevel)
-            self.percent = Int(UIDevice.current.batteryLevel * 100)
-            self.state = UIDevice.current.batteryState
-        }
+        UIDevice.current.isBatteryMonitoringEnabled = true
+        self.percent = max(0, Int(UIDevice.current.batteryLevel * 100))
+        self.state = UIDevice.current.batteryState
 
         if UIDevice.current.model == "iPhone" {
             self.model = Model.iPhone
@@ -56,8 +52,8 @@ enum Model {
         )
     }
     @objc func batteryLevelDidChange(notification: Notification) {
-         percent = Int(UIDevice.current.batteryLevel * 100)
-     }
+         percent = max(0, Int(UIDevice.current.batteryLevel * 100))
+      }
 
      @objc func batteryStateDidChange(notification: Notification) {
          state = UIDevice.current.batteryState

--- a/Shared/Car.swift
+++ b/Shared/Car.swift
@@ -6,6 +6,9 @@
 //
 
 import Foundation
+import os
+
+private let logger = Logger(subsystem: "io.fluxhaus.FluxHaus", category: "Car")
 
 // Car-specific logic and classes
 // Note: Shared types are now defined in LoginStucts.swift
@@ -39,29 +42,27 @@ import Foundation
         if let response = apiResponse?.response,
            let fluxCar = response.car,
            let evStatus = response.carEvStatus {
-            DispatchQueue.main.async {
-                self.vehicle = CarDetails(
-                    timestamp: fluxCar.timestamp,
-                    evStatusTimestamp: evStatus.timestamp,
-                    batteryLevel: evStatus.batteryStatus,
-                    distance: evStatus.drvDistance[0].rangeByFuel.evModeRange.value,
-                    hvac: fluxCar.airCtrlOn,
-                    pluggedIn: evStatus.batteryPlugin == 0 ? false : true,
-                    batteryCharge: evStatus.batteryCharge,
-                    locked: fluxCar.doorLock,
-                    doorsOpen: Doors(
-                        frontRight: fluxCar.doorOpen.frontRight,
-                        frontLeft: fluxCar.doorOpen.frontLeft,
-                        backRight: fluxCar.doorOpen.backRight,
-                        backLeft: fluxCar.doorOpen.backLeft
-                    ),
-                    trunkOpen: fluxCar.trunkOpen,
-                    defrost: fluxCar.defrost,
-                    hoodOpen: fluxCar.hoodOpen,
-                    odometer: response.carOdometer ?? 0,
-                    engine: fluxCar.engine
-                )
-            }
+            vehicle = CarDetails(
+                timestamp: fluxCar.timestamp,
+                evStatusTimestamp: evStatus.timestamp,
+                batteryLevel: evStatus.batteryStatus,
+                distance: evStatus.drvDistance[0].rangeByFuel.evModeRange.value,
+                hvac: fluxCar.airCtrlOn,
+                pluggedIn: evStatus.batteryPlugin != 0,
+                batteryCharge: evStatus.batteryCharge,
+                locked: fluxCar.doorLock,
+                doorsOpen: Doors(
+                    frontRight: fluxCar.doorOpen.frontRight,
+                    frontLeft: fluxCar.doorOpen.frontLeft,
+                    backRight: fluxCar.doorOpen.backRight,
+                    backLeft: fluxCar.doorOpen.backLeft
+                ),
+                trunkOpen: fluxCar.trunkOpen,
+                defrost: fluxCar.defrost,
+                hoodOpen: fluxCar.hoodOpen,
+                odometer: response.carOdometer ?? 0,
+                engine: fluxCar.engine
+            )
         }
     }
 
@@ -126,13 +127,14 @@ import Foundation
                 request.httpBody = try? JSONSerialization.data(withJSONObject: body)
             }
 
-            let session = URLSession(configuration: .default)
-            let task = session.dataTask(with: request) { @Sendable (data: Data?, _: URLResponse?, _: Error?) in
-                if data != nil {
-                    print("Got data \(path)")
-                }
+            do {
+                let session = URLSession(configuration: .default)
+                let (_, response) = try await session.data(for: request)
+                let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+                logger.info("Car action \(path) completed with HTTP \(statusCode)")
+            } catch {
+                logger.error("Car action \(path) failed: \(error.localizedDescription)")
             }
-            task.resume()
         }
     }
 }

--- a/Shared/CarDetailView.swift
+++ b/Shared/CarDetailView.swift
@@ -12,7 +12,7 @@ import CoreLocation
 struct CarDetailView: View {
     @Environment(\.presentationMode) var presentationMode
     var car: Car
-    @ObservedObject var locationManager: LocationManager
+    var locationManager: LocationManager
     @State private var buttonsDisabled: Bool = false
     @State var apiResponse: Api?
 
@@ -399,7 +399,7 @@ struct CarDetailView: View {
 
 struct CarClimateView: View {
     var car: Car
-    @ObservedObject var locationManager: LocationManager
+    var locationManager: LocationManager
     @Environment(\.presentationMode) var presentationMode
 
     @State private var steeringWheelHeat: Bool = false

--- a/Shared/FluxHausConsts.swift
+++ b/Shared/FluxHausConsts.swift
@@ -12,9 +12,9 @@ struct FluxHausConfig {
     let favouriteScenes: [String]
 }
 
-class FluxHausConsts: ObservableObject {
-    @Published var favouriteHomeKit: [String] = []
-    @Published var favouriteScenes: [String] = []
+@Observable class FluxHausConsts {
+    var favouriteHomeKit: [String] = []
+    var favouriteScenes: [String] = []
 
     func setConfig(config: FluxHausConfig) {
         self.favouriteHomeKit = config.favouriteHomeKit

--- a/Shared/HomeConnect.swift
+++ b/Shared/HomeConnect.swift
@@ -9,8 +9,8 @@ import Foundation
 // Note: Shared types are now defined in LoginStucts.swift
 
 @MainActor
-class HomeConnect: ObservableObject {
-    @Published var appliances: [Appliance] = []
+@Observable class HomeConnect {
+    var appliances: [Appliance] = []
     var apiResponse: Api?
 
     init(apiResponse: Api) {
@@ -53,7 +53,7 @@ class HomeConnect: ObservableObject {
 
         timeRemaining = (program.remainingTime ?? 0) / 60
         if program.activeProgram != nil {
-            options = [program.activeProgram!.rawValue]
+            options = [program.selectedProgram ?? program.activeProgram!.rawValue]
         }
 
         let currentDate = Date()

--- a/Shared/HomeConnect.swift
+++ b/Shared/HomeConnect.swift
@@ -52,8 +52,9 @@ import Foundation
         var timeRemaining = 0
 
         timeRemaining = (program.remainingTime ?? 0) / 60
-        if program.activeProgram != nil {
-            options = [program.selectedProgram ?? program.activeProgram!.rawValue]
+        if let activeProgram = program.activeProgram {
+            // The API's selected program is the user-facing name; fall back to the enum value.
+            options = [program.selectedProgram ?? activeProgram.rawValue]
         }
 
         let currentDate = Date()

--- a/Shared/HomeKitIntegration.swift
+++ b/Shared/HomeKitIntegration.swift
@@ -16,10 +16,10 @@ struct HomeKitFavourite {
 }
 
 @MainActor
-class HomeKitIntegration: NSObject, ObservableObject, HMHomeDelegate, HMHomeManagerDelegate {
-    @Published var homeManager = HMHomeManager()
-    @Published var favourites: [HomeKitFavourite] = []
-    @Published var primaryHome: HMHome?
+@Observable class HomeKitIntegration: NSObject, HMHomeDelegate, HMHomeManagerDelegate {
+    var homeManager = HMHomeManager()
+    var favourites: [HomeKitFavourite] = []
+    var primaryHome: HMHome?
 
     override init() {
         super.init()

--- a/Shared/HomeKitView.swift
+++ b/Shared/HomeKitView.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct HomeKitView: View {
     var favouriteHomeKit: [String]
 
-    @StateObject var home = HomeKitIntegration()
+    @State var home = HomeKitIntegration()
     private let gridItemLayout = [GridItem(.flexible())]
     var body: some View {
         ScrollView(.horizontal) {

--- a/Shared/Login.swift
+++ b/Shared/Login.swift
@@ -7,8 +7,8 @@
 
 import Foundation
 
-class LoginViewModel: ObservableObject {
-    @Published var password: String = ""
+@Observable class LoginViewModel {
+    var password: String = ""
 
     func login() {
         LoginAction(

--- a/Shared/Miele.swift
+++ b/Shared/Miele.swift
@@ -8,8 +8,8 @@
 import Foundation
 
 @MainActor
-class Miele: ObservableObject {
-    @Published var appliances: [Appliance] = []
+@Observable class Miele {
+    var appliances: [Appliance] = []
     var apiResponse: Api?
 
     init(apiResponse: Api) {

--- a/Shared/QueryFlux.swift
+++ b/Shared/QueryFlux.swift
@@ -117,56 +117,61 @@ private func buildFluxAPIRequest(password: String) -> URLRequest? {
 }
 
 func queryFlux(password: String) {
-    queryFluxWithRetry(password: password, attempt: 0)
+    Task {
+        await queryFluxWithRetry(password: password, attempt: 0)
+    }
 }
 
-private func queryFluxWithRetry(password: String, attempt: Int) {
+private func queryFluxWithRetry(password: String, attempt: Int) async {
     guard let request = buildFluxAPIRequest(password: password) else { return }
 
-    let session = URLSession(configuration: .default, delegate: nil, delegateQueue: nil)
-    let task = session.dataTask(with: request) { data, response, error in
+    do {
+        let session = URLSession(configuration: .default, delegate: nil, delegateQueue: nil)
+        let (data, response) = try await session.data(for: request)
         let httpResponse = response as? HTTPURLResponse
 
         if httpResponse?.statusCode == 401 {
-            handleUnauthorized(password: password)
+            await handleUnauthorized(password: password)
             return
         }
 
-        if let error = error {
-            if isTransientNetworkError(error) && attempt < RetryConfig().maxRetries {
-                let delayMs = RetryConfig().delayMs(for: attempt)
-                logger.warning("queryFlux: transient error on attempt \(attempt + 1), retrying in \(delayMs)ms")
-                DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(Int(delayMs))) {
-                    queryFluxWithRetry(password: password, attempt: attempt + 1)
-                }
-                return
-            }
+        await handleQueryFluxResponse(data: data, error: nil, password: password)
+    } catch {
+        if isTransientNetworkError(error) && attempt < RetryConfig().maxRetries {
+            let delayMs = RetryConfig().delayMs(for: attempt)
+            logger.warning("queryFlux: transient error on attempt \(attempt + 1), retrying in \(delayMs)ms")
+            try? await Task.sleep(for: .milliseconds(delayMs))
+            await queryFluxWithRetry(password: password, attempt: attempt + 1)
+            return
         }
-
-        handleQueryFluxResponse(data: data, error: error, password: password)
+        await handleQueryFluxResponse(data: nil, error: error, password: password)
     }
-    task.resume()
 }
 
-private func handleUnauthorized(password: String) {
+private func handleUnauthorized(password: String) async {
     if AuthManager.shared.getAccessToken() != nil {
         logger.debug("handleUnauthorized: 401 with OIDC token, requesting refresh")
-        Task { @MainActor in
+        await MainActor.run {
             let oldToken = AuthManager.shared.getAccessToken()?.suffix(8) ?? "nil"
-            let refreshed = await AuthManager.shared.refreshTokenIfNeeded()
-            if refreshed {
-                let newToken = AuthManager.shared.getAccessToken()?.suffix(8) ?? "nil"
-                logger.debug("handleUnauthorized: refresh succeeded (…\(oldToken) → …\(newToken)), retrying")
-                retryQueryFlux(password: password)
-            } else if AuthManager.shared.isSignedOut {
-                logger.error("handleUnauthorized: refresh rejected — signed out")
+            logger.debug("handleUnauthorized: refreshing token after 401 (old token …\(oldToken))")
+        }
+        let refreshed = await AuthManager.shared.refreshTokenIfNeeded()
+        if refreshed {
+            let newToken = AuthManager.shared.getAccessToken()?.suffix(8) ?? "nil"
+            logger.debug("handleUnauthorized: refresh succeeded (new token …\(newToken)), retrying")
+            await retryQueryFlux(password: password)
+        } else if await MainActor.run(body: { AuthManager.shared.isSignedOut }) {
+            logger.error("handleUnauthorized: refresh rejected — signed out")
+            await MainActor.run {
                 NotificationCenter.default.post(
                     name: Notification.Name.loginsUpdated,
                     object: nil,
                     userInfo: ["keysFailed": true]
                 )
-            } else {
-                logger.warning("handleUnauthorized: refresh failed transiently, keeping session")
+            }
+        } else {
+            logger.warning("handleUnauthorized: refresh failed transiently, keeping session")
+            await MainActor.run {
                 NotificationCenter.default.post(
                     name: Notification.Name.loginsUpdated,
                     object: nil,
@@ -176,7 +181,7 @@ private func handleUnauthorized(password: String) {
         }
     } else {
         logger.error("handleUnauthorized: demo auth failed — signing out and posting loginError")
-        DispatchQueue.main.async {
+        await MainActor.run {
             AuthManager.shared.signOut()
             NotificationCenter.default.post(
                 name: Notification.Name.loginsUpdated,
@@ -188,15 +193,16 @@ private func handleUnauthorized(password: String) {
 }
 
 /// Single retry after token refresh — signs out on second 401 without further retry.
-private func retryQueryFlux(password: String) {
+private func retryQueryFlux(password: String) async {
     guard let request = buildFluxAPIRequest(password: password) else { return }
 
-    let session = URLSession(configuration: .default, delegate: nil, delegateQueue: nil)
-    let task = session.dataTask(with: request) { data, response, error in
+    do {
+        let session = URLSession(configuration: .default, delegate: nil, delegateQueue: nil)
+        let (data, response) = try await session.data(for: request)
         let httpResponse = response as? HTTPURLResponse
         if httpResponse?.statusCode == 401 {
             logger.error("retryQueryFlux: still 401 after refresh — signing out")
-            DispatchQueue.main.async {
+            await MainActor.run {
                 AuthManager.shared.signOut()
                 NotificationCenter.default.post(
                     name: Notification.Name.loginsUpdated,
@@ -206,16 +212,17 @@ private func retryQueryFlux(password: String) {
             }
             return
         }
-        handleQueryFluxResponse(data: data, error: error, password: password)
+        await handleQueryFluxResponse(data: data, error: nil, password: password)
+    } catch {
+        await handleQueryFluxResponse(data: nil, error: error, password: password)
     }
-    task.resume()
 }
 
-private func handleQueryFluxResponse(data: Data?, error: Error?, password: String) {
+private func handleQueryFluxResponse(data: Data?, error: Error?, password: String) async {
     if let data = data {
         do {
             let response = try JSONDecoder().decode(LoginResponse.self, from: data)
-            DispatchQueue.main.async {
+            await MainActor.run {
                 AuthManager.shared.isCompletingOIDCLogin = false
                 if AuthManager.shared.getAccessToken() != nil {
                     AuthManager.shared.markOIDCSessionValid()
@@ -247,7 +254,7 @@ private func handleQueryFluxResponse(data: Data?, error: Error?, password: Strin
             if let jsonStr = String(data: data, encoding: .utf8) {
                 logger.error("Response body: \(jsonStr.prefix(500))")
             }
-            DispatchQueue.main.async {
+            await MainActor.run {
                 AuthManager.shared.isCompletingOIDCLogin = false
                 NotificationCenter.default.post(
                     name: Notification.Name.loginsUpdated,
@@ -260,7 +267,7 @@ private func handleQueryFluxResponse(data: Data?, error: Error?, password: Strin
         // Only post error for non-transient failures
         if !isTransientNetworkError(error) {
             logger.error("handleQueryFluxResponse: non-transient error: \(error.localizedDescription)")
-            DispatchQueue.main.async {
+            await MainActor.run {
                 AuthManager.shared.isCompletingOIDCLogin = false
                 NotificationCenter.default.post(
                     name: Notification.Name.loginsUpdated,
@@ -272,7 +279,7 @@ private func handleQueryFluxResponse(data: Data?, error: Error?, password: Strin
             // Transient network error but retries exhausted
             let msg = "transient error exhausted after retries"
             logger.error("handleQueryFluxResponse: \(msg): \(error.localizedDescription)")
-            DispatchQueue.main.async {
+            await MainActor.run {
                 AuthManager.shared.isCompletingOIDCLogin = false
                 NotificationCenter.default.post(
                     name: Notification.Name.loginsUpdated,
@@ -282,7 +289,7 @@ private func handleQueryFluxResponse(data: Data?, error: Error?, password: Strin
             }
         }
     } else {
-        DispatchQueue.main.async {
+        await MainActor.run {
             AuthManager.shared.isCompletingOIDCLogin = false
         }
     }

--- a/Shared/QueryFlux.swift
+++ b/Shared/QueryFlux.swift
@@ -10,6 +10,8 @@ import os
 
 private let logger = Logger(subsystem: "io.fluxhaus.FluxHaus", category: "QueryFlux")
 
+@MainActor private var activeQueryFluxTask: Task<Void, Never>?
+
 // MARK: - Helper Functions
 
 /// Check if a login error message indicates an authentication failure (vs transient/server issue)
@@ -117,8 +119,11 @@ private func buildFluxAPIRequest(password: String) -> URLRequest? {
 }
 
 func queryFlux(password: String) {
-    Task {
-        await queryFluxWithRetry(password: password, attempt: 0)
+    Task { @MainActor in
+        activeQueryFluxTask?.cancel()
+        activeQueryFluxTask = Task {
+            await queryFluxWithRetry(password: password, attempt: 0)
+        }
     }
 }
 
@@ -136,11 +141,14 @@ private func queryFluxWithRetry(password: String, attempt: Int) async {
         }
 
         await handleQueryFluxResponse(data: data, error: nil, password: password)
+    } catch is CancellationError {
+        return
     } catch {
         if isTransientNetworkError(error) && attempt < RetryConfig().maxRetries {
             let delayMs = RetryConfig().delayMs(for: attempt)
             logger.warning("queryFlux: transient error on attempt \(attempt + 1), retrying in \(delayMs)ms")
             try? await Task.sleep(for: .milliseconds(delayMs))
+            guard !Task.isCancelled else { return }
             await queryFluxWithRetry(password: password, attempt: attempt + 1)
             return
         }
@@ -151,14 +159,11 @@ private func queryFluxWithRetry(password: String, attempt: Int) async {
 private func handleUnauthorized(password: String) async {
     if AuthManager.shared.getAccessToken() != nil {
         logger.debug("handleUnauthorized: 401 with OIDC token, requesting refresh")
-        await MainActor.run {
-            let oldToken = AuthManager.shared.getAccessToken()?.suffix(8) ?? "nil"
-            logger.debug("handleUnauthorized: refreshing token after 401 (old token …\(oldToken))")
-        }
+        let oldToken = AuthManager.shared.getAccessToken()?.suffix(8) ?? "nil"
         let refreshed = await AuthManager.shared.refreshTokenIfNeeded()
         if refreshed {
             let newToken = AuthManager.shared.getAccessToken()?.suffix(8) ?? "nil"
-            logger.debug("handleUnauthorized: refresh succeeded (new token …\(newToken)), retrying")
+            logger.debug("handleUnauthorized: refresh succeeded (…\(oldToken) → …\(newToken)), retrying")
             await retryQueryFlux(password: password)
         } else if await MainActor.run(body: { AuthManager.shared.isSignedOut }) {
             logger.error("handleUnauthorized: refresh rejected — signed out")
@@ -213,6 +218,8 @@ private func retryQueryFlux(password: String) async {
             return
         }
         await handleQueryFluxResponse(data: data, error: nil, password: password)
+    } catch is CancellationError {
+        return
     } catch {
         await handleQueryFluxResponse(data: nil, error: error, password: password)
     }

--- a/Shared/Robots.swift
+++ b/Shared/Robots.swift
@@ -6,6 +6,9 @@
 //
 
 import Foundation
+import os
+
+private let logger = Logger(subsystem: "io.fluxhaus.FluxHaus", category: "Robots")
 
 // Robot-specific logic and classes
 // Note: Shared types are now defined in LoginStucts.swift
@@ -45,30 +48,28 @@ import Foundation
 
     func fetchRobots() {
         if let response = apiResponse?.response {
-            DispatchQueue.main.async {
-                self.mopBot = Robot(
-                    name: "MopBot",
-                    timestamp: response.mopbot.timestamp,
-                    batteryLevel: response.mopbot.batteryLevel,
-                    binFull: response.mopbot.binFull,
-                    running: response.mopbot.running,
-                    charging: response.mopbot.charging,
-                    docking: response.mopbot.docking,
-                    paused: response.mopbot.paused,
-                    timeStarted: response.mopbot.timeStarted
-                )
-                self.broomBot = Robot(
-                    name: "BroomBot",
-                    timestamp: response.broombot.timestamp,
-                    batteryLevel: response.broombot.batteryLevel,
-                    binFull: response.broombot.binFull,
-                    running: response.broombot.running,
-                    charging: response.broombot.charging,
-                    docking: response.broombot.docking,
-                    paused: response.broombot.paused,
-                    timeStarted: response.broombot.timeStarted
-                )
-            }
+            mopBot = Robot(
+                name: "MopBot",
+                timestamp: response.mopbot.timestamp,
+                batteryLevel: response.mopbot.batteryLevel,
+                binFull: response.mopbot.binFull,
+                running: response.mopbot.running,
+                charging: response.mopbot.charging,
+                docking: response.mopbot.docking,
+                paused: response.mopbot.paused,
+                timeStarted: response.mopbot.timeStarted
+            )
+            broomBot = Robot(
+                name: "BroomBot",
+                timestamp: response.broombot.timestamp,
+                batteryLevel: response.broombot.batteryLevel,
+                binFull: response.broombot.binFull,
+                running: response.broombot.running,
+                charging: response.broombot.charging,
+                docking: response.broombot.docking,
+                paused: response.broombot.paused,
+                timeStarted: response.broombot.timeStarted
+            )
         }
     }
 
@@ -110,13 +111,14 @@ import Foundation
             if let csrfToken = csrfToken {
                 request.setValue(csrfToken, forHTTPHeaderField: "X-CSRF-Token")
             }
-            let session = URLSession(configuration: .default)
-            let task = session.dataTask(with: request) { @Sendable (data: Data?, _: URLResponse?, _: Error?) in
-                if data != nil {
-                    print("Got Robot data \(path)")
-                }
+            do {
+                let session = URLSession(configuration: .default)
+                let (_, response) = try await session.data(for: request)
+                let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+                logger.info("Robot action \(path) completed with HTTP \(statusCode)")
+            } catch {
+                logger.error("Robot action \(path) failed: \(error.localizedDescription)")
             }
-            task.resume()
         }
     }
 }

--- a/Shared/Weather.swift
+++ b/Shared/Weather.swift
@@ -33,13 +33,13 @@ struct ForecastInfo {
 
 // MARK: - Location services
 @MainActor
-@preconcurrency class LocationManager: NSObject, ObservableObject, CLLocationManagerDelegate {
+@preconcurrency @Observable class LocationManager: NSObject, CLLocationManagerDelegate {
     private let locationManager = CLLocationManager()
     private var status: CLAuthorizationStatus?
     private var location: CLLocation?
-    @Published var weather: Weather?
-    @Published var forecast: ForecastInfo?
-    @Published var weatherError: String?
+    var weather: Weather?
+    var forecast: ForecastInfo?
+    var weatherError: String?
     private var retryCount = 0
     private static let maxRetries = 3
 

--- a/Shared/WeatherView.swift
+++ b/Shared/WeatherView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct WeatherView: View {
-    @ObservedObject var lman: LocationManager
+    var lman: LocationManager
     @State private var showModal: Bool = false
     @Environment(\.colorScheme) var colorScheme
 

--- a/Tests iOS/MockDataUITests.swift
+++ b/Tests iOS/MockDataUITests.swift
@@ -10,14 +10,10 @@ import SwiftUI
 import UIKit
 @testable import FluxHaus
 
-/// Drains pending DispatchQueue.main.async blocks so data population completes.
+/// Gives main-actor updates a turn to complete before assertions.
 @MainActor
 private func drainMainQueue() async {
-    await withCheckedContinuation { continuation in
-        DispatchQueue.main.async {
-            continuation.resume()
-        }
-    }
+    await Task.yield()
 }
 
 /// Creates a LoginResponse with all device fields nil (minimal/empty state).

--- a/Tests macOS/Tests_macOS_SwiftTesting.swift
+++ b/Tests macOS/Tests_macOS_SwiftTesting.swift
@@ -10,14 +10,10 @@ import Testing
 import AppKit
 import SwiftUI
 
-/// Drains pending DispatchQueue.main.async blocks so data population completes.
+/// Gives main-actor updates a turn to complete before assertions.
 @MainActor
 private func drainMainQueue() async {
-    await withCheckedContinuation { continuation in
-        DispatchQueue.main.async {
-            continuation.resume()
-        }
-    }
+    await Task.yield()
 }
 
 /// Creates a LoginResponse with all device fields nil (minimal/empty state).

--- a/Tests macOS/Tests_macOS_ViewTests.swift
+++ b/Tests macOS/Tests_macOS_ViewTests.swift
@@ -12,14 +12,10 @@ import AppKit
 import SwiftUI
 import Carbon
 
-/// Drains pending DispatchQueue.main.async blocks so data population completes.
+/// Gives main-actor updates a turn to complete before assertions.
 @MainActor
 private func drainMainQueueForViews() async {
-    await withCheckedContinuation { continuation in
-        DispatchQueue.main.async {
-            continuation.resume()
-        }
-    }
+    await Task.yield()
 }
 
 /// Creates a LoginResponse with all device fields nil.

--- a/VisionOS/ContentView.swift
+++ b/VisionOS/ContentView.swift
@@ -19,8 +19,8 @@ struct ContentView: View {
     var scooter: Scooter
     var apiResponse: Api
     @State private var whereWeAre = WhereWeAre()
-    @StateObject private var locationManager = LocationManager()
-    @StateObject private var authManager = AuthManager.shared
+    @State private var locationManager = LocationManager()
+    @State private var authManager = AuthManager.shared
     @State private var chat = Chat()
     @State private var radarService = RadarService()
     @State private var selectedTab = "Home"

--- a/VisionOS/LoadingView.swift
+++ b/VisionOS/LoadingView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct LoadingView: View {
     var needLoginView: Bool
-    @ObservedObject var viewModel: LoginViewModel = LoginViewModel()
+    @State var viewModel = LoginViewModel()
 
     @State var error: String?
     @State var loggedIn: Bool = false
@@ -69,15 +69,11 @@ struct LoadingView: View {
             }
             .onReceive(NotificationCenter.default.publisher(for: Notification.Name.loginsUpdated)) { object in
                 if (object.userInfo?["loginError"]) != nil {
-                    DispatchQueue.main.async {
-                        self.error = object.userInfo!["loginError"] as? String
-                        self.isSigningIn = false
-                    }
+                    self.error = object.userInfo!["loginError"] as? String
+                    self.isSigningIn = false
                 }
                 if (object.userInfo?["keysComplete"]) != nil {
-                    DispatchQueue.main.async {
-                        self.loggedIn = true
-                    }
+                    self.loggedIn = true
                 }
             }
         } else {

--- a/VisionOS/VisionOSApp.swift
+++ b/VisionOS/VisionOSApp.swift
@@ -190,10 +190,11 @@ struct VisionOSApp: App {
 
     private func runPeriodicRefresh() async {
         while !Task.isCancelled {
+            if AuthManager.shared.isSignedIn {
+                _ = await AuthManager.shared.ensureValidToken()
+                queryFlux(password: WhereWeAre.getPassword() ?? "")
+            }
             try? await Task.sleep(for: .seconds(5))
-            guard !Task.isCancelled, AuthManager.shared.isSignedIn else { continue }
-            _ = await AuthManager.shared.ensureValidToken()
-            queryFlux(password: WhereWeAre.getPassword() ?? "")
         }
     }
 }

--- a/VisionOS/VisionOSApp.swift
+++ b/VisionOS/VisionOSApp.swift
@@ -11,22 +11,20 @@ import os
 
 private let appLogger = Logger(subsystem: "io.fluxhaus.FluxHaus", category: "VisionOSApp")
 
-@MainActor var hconn: HomeConnect?
-@MainActor var miele: Miele?
-@MainActor var robots: Robots?
-@MainActor var battery: Battery?
-@MainActor var car: Car?
-@MainActor var scooter: Scooter?
-
 @main
 struct VisionOSApp: App {
 
     @State private var whereWeAre = WhereWeAre()
     @State var fluxHausConsts = FluxHausConsts()
     @State var apiResponse = Api()
+    @State private var hconn: HomeConnect?
+    @State private var miele: Miele?
+    @State private var robots: Robots?
+    @State private var battery: Battery?
+    @State private var car: Car?
+    @State private var scooter: Scooter?
 
     @Environment(\.scenePhase) private var scenePhase
-    let timer = Timer.publish(every: 5, on: .main, in: .common).autoconnect()
 
     var body: some Scene {
         WindowGroup {
@@ -115,13 +113,8 @@ struct VisionOSApp: App {
                                 scooter.setApiResponse(apiResponse: self.apiResponse)
                             }
                         }
-                        .onReceive(timer) {_ in
-                            if AuthManager.shared.isSignedIn {
-                                Task {
-                                    _ = await AuthManager.shared.ensureValidToken()
-                                }
-                                queryFlux(password: WhereWeAre.getPassword() ?? "")
-                            }
+                        .task {
+                            await runPeriodicRefresh()
                         }
                     }
                 }
@@ -193,5 +186,14 @@ struct VisionOSApp: App {
     func loadScooter() {
         scooter = Scooter()
         scooter?.setApiResponse(apiResponse: self.apiResponse)
+    }
+
+    private func runPeriodicRefresh() async {
+        while !Task.isCancelled {
+            try? await Task.sleep(for: .seconds(5))
+            guard !Task.isCancelled, AuthManager.shared.isSignedIn else { continue }
+            _ = await AuthManager.shared.ensureValidToken()
+            queryFlux(password: WhereWeAre.getPassword() ?? "")
+        }
     }
 }

--- a/iOS/ContentView.swift
+++ b/iOS/ContentView.swift
@@ -17,8 +17,8 @@ struct ContentView: View {
     var scooter: Scooter
     var apiResponse: Api
     @State private var whereWeAre = WhereWeAre()
-    @StateObject private var locationManager = LocationManager()
-    @StateObject private var authManager = AuthManager.shared
+    @State private var locationManager = LocationManager()
+    @State private var authManager = AuthManager.shared
     @State private var chat = Chat()
     @State private var radarService = RadarService()
     @State private var selectedTab = "home"

--- a/iOS/FluxHausApp.swift
+++ b/iOS/FluxHausApp.swift
@@ -38,7 +38,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
             }
             appLogger.info("Notification authorization granted: \(granted)")
             if granted {
-                DispatchQueue.main.async {
+                Task { @MainActor in
                     application.registerForRemoteNotifications()
                 }
             }
@@ -142,13 +142,6 @@ class AppDelegate: NSObject, UIApplicationDelegate {
     }
 }
 
-@MainActor var hconn: HomeConnect?
-@MainActor var miele: Miele?
-@MainActor var robots: Robots?
-@MainActor var battery: Battery?
-@MainActor var car: Car?
-@MainActor var scooter: Scooter?
-
 @main
 struct FluxHausApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
@@ -156,9 +149,13 @@ struct FluxHausApp: App {
     @State var fluxHausConsts = FluxHausConsts()
     @State private var battery = Battery()
     @State var apiResponse = Api()
+    @State private var hconn: HomeConnect?
+    @State private var miele: Miele?
+    @State private var robots: Robots?
+    @State private var car: Car?
+    @State private var scooter: Scooter?
 
     @Environment(\.scenePhase) private var scenePhase
-    let timer = Timer.publish(every: 5, on: .main, in: .common).autoconnect()
 
     var body: some Scene {
         WindowGroup {
@@ -248,13 +245,8 @@ struct FluxHausApp: App {
                             updateLiveActivities(response: response)
                         }
                     }
-                    .onReceive(timer) {_ in
-                        if AuthManager.shared.isSignedIn {
-                            Task {
-                                _ = await AuthManager.shared.ensureValidToken()
-                                queryFlux(password: WhereWeAre.getPassword() ?? "")
-                            }
-                        }
+                    .task {
+                        await runPeriodicRefresh()
                     }
                 }
             }
@@ -369,5 +361,14 @@ struct FluxHausApp: App {
             object: nil,
             userInfo: ["section": section]
         )
+    }
+
+    private func runPeriodicRefresh() async {
+        while !Task.isCancelled {
+            try? await Task.sleep(for: .seconds(5))
+            guard !Task.isCancelled, AuthManager.shared.isSignedIn else { continue }
+            _ = await AuthManager.shared.ensureValidToken()
+            queryFlux(password: WhereWeAre.getPassword() ?? "")
+        }
     }
 }

--- a/iOS/FluxHausApp.swift
+++ b/iOS/FluxHausApp.swift
@@ -365,10 +365,11 @@ struct FluxHausApp: App {
 
     private func runPeriodicRefresh() async {
         while !Task.isCancelled {
+            if AuthManager.shared.isSignedIn {
+                _ = await AuthManager.shared.ensureValidToken()
+                queryFlux(password: WhereWeAre.getPassword() ?? "")
+            }
             try? await Task.sleep(for: .seconds(5))
-            guard !Task.isCancelled, AuthManager.shared.isSignedIn else { continue }
-            _ = await AuthManager.shared.ensureValidToken()
-            queryFlux(password: WhereWeAre.getPassword() ?? "")
         }
     }
 }

--- a/macOS/ChatView.swift
+++ b/macOS/ChatView.swift
@@ -526,7 +526,7 @@ extension ChatView {
                     mediaType: "image/jpeg",
                     base64: jpeg.base64EncodedString()
                 )
-                DispatchQueue.main.async {
+                Task { @MainActor in
                     pendingImages.append(chatImage)
                 }
             }

--- a/macOS/ContentView.swift
+++ b/macOS/ContentView.swift
@@ -43,8 +43,8 @@ struct ContentView: View {
     var scooter: Scooter
     var apiResponse: Api
     var chat: Chat
-    @StateObject private var locationManager = LocationManager()
-    @StateObject private var authManager = AuthManager.shared
+    @State private var locationManager = LocationManager()
+    @State private var authManager = AuthManager.shared
     @State private var radarService = RadarService()
     @State private var selectedItem: SidebarItem = .dashboard
 

--- a/macOS/DashboardView.swift
+++ b/macOS/DashboardView.swift
@@ -16,7 +16,7 @@ struct DashboardView: View {
     var car: Car
     var scooter: Scooter
     var apiResponse: Api
-    @ObservedObject var locationManager: LocationManager
+    var locationManager: LocationManager
     var radarService: RadarService
     var onNavigate: (SidebarItem) -> Void
     @State private var sceneManager = SceneManager()

--- a/macOS/LoginView.swift
+++ b/macOS/LoginView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct LoginView: View {
     var needLoginView: Bool
-    @ObservedObject var viewModel: LoginViewModel = LoginViewModel()
+    @State private var viewModel = LoginViewModel()
     @State private var isSigningIn = false
     @State private var showDemoLogin = false
     @State private var errorMessage: String?

--- a/macOS/MacApp.swift
+++ b/macOS/MacApp.swift
@@ -366,8 +366,6 @@ struct MacApp: App {
     @State private var scooter: Scooter?
     @AppStorage("showMenuBarExtra") private var showMenuBar = true
 
-    let timer = Timer.publish(every: 5, on: .main, in: .common).autoconnect()
-
     var body: some Scene {
         WindowGroup {
             mainContent
@@ -510,13 +508,8 @@ struct MacApp: App {
                     scooter.setApiResponse(apiResponse: self.apiResponse)
                 }
             }
-            .onReceive(timer) { _ in
-                if AuthManager.shared.isSignedIn {
-                    Task {
-                        _ = await AuthManager.shared.ensureValidToken()
-                        queryFlux(password: WhereWeAre.getPassword() ?? "")
-                    }
-                }
+            .task {
+                await runPeriodicRefresh()
             }
         }
     }
@@ -571,6 +564,15 @@ struct MacApp: App {
         let capitalized = section.prefix(1).uppercased() + section.dropFirst()
         appLogger.info("Deep link: \(capitalized)")
         postNavigation(capitalized)
+    }
+
+    private func runPeriodicRefresh() async {
+        while !Task.isCancelled {
+            try? await Task.sleep(for: .seconds(5))
+            guard !Task.isCancelled, AuthManager.shared.isSignedIn else { continue }
+            _ = await AuthManager.shared.ensureValidToken()
+            queryFlux(password: WhereWeAre.getPassword() ?? "")
+        }
     }
 
     private func handleDataUpdated(_ object: NotificationCenter.Publisher.Output) {

--- a/macOS/MacApp.swift
+++ b/macOS/MacApp.swift
@@ -568,10 +568,11 @@ struct MacApp: App {
 
     private func runPeriodicRefresh() async {
         while !Task.isCancelled {
+            if AuthManager.shared.isSignedIn {
+                _ = await AuthManager.shared.ensureValidToken()
+                queryFlux(password: WhereWeAre.getPassword() ?? "")
+            }
             try? await Task.sleep(for: .seconds(5))
-            guard !Task.isCancelled, AuthManager.shared.isSignedIn else { continue }
-            _ = await AuthManager.shared.ensureValidToken()
-            queryFlux(password: WhereWeAre.getPassword() ?? "")
         }
     }
 

--- a/macOS/MenuBarView.swift
+++ b/macOS/MenuBarView.swift
@@ -14,7 +14,7 @@ struct MenuBarView: View {
     var hconn: HomeConnect?
     var favouriteScenes: [String]
     @State private var sceneManager = SceneManager()
-    @ObservedObject private var authManager = AuthManager.shared
+    @State private var authManager = AuthManager.shared
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {

--- a/macOS/RadarOverlayRenderer.swift
+++ b/macOS/RadarOverlayRenderer.swift
@@ -200,7 +200,11 @@ class RadarAnimationRenderer: MKOverlayRenderer, @unchecked Sendable {
         }
 
         Task { [weak self] in
-            defer { onComplete?() }
+            defer {
+                if let onComplete {
+                    Task { @MainActor in onComplete() }
+                }
+            }
             guard let self else { return }
 
             do {

--- a/macOS/RadarOverlayRenderer.swift
+++ b/macOS/RadarOverlayRenderer.swift
@@ -194,29 +194,48 @@ class RadarAnimationRenderer: MKOverlayRenderer, @unchecked Sendable {
         lock.unlock()
 
         guard let url = urlBuilder(path, zoom, col, row) else {
+            finishPending(key)
             onComplete?()
             return
         }
 
-        URLSession.shared.dataTask(with: url) { [weak self] data, _, _ in
+        Task { [weak self] in
             defer { onComplete?() }
-            guard let self, let data,
-                  let src = CGImageSourceCreateWithData(
-                      data as CFData, nil),
-                  let img = CGImageSourceCreateImageAtIndex(
-                      src, 0, nil)
-            else { return }
+            guard let self else { return }
 
-            self.lock.lock()
-            self.cache[key] = img
-            self.pending.remove(key)
-            self.lock.unlock()
+            do {
+                let (data, _) = try await URLSession.shared.data(from: url)
+                guard let src = CGImageSourceCreateWithData(data as CFData, nil),
+                      let img = CGImageSourceCreateImageAtIndex(src, 0, nil)
+                else {
+                    finishPending(key)
+                    return
+                }
 
-            let tRect = self.tileMapRect(col: col, row: row, zoom: zoom)
-            DispatchQueue.main.async {
-                self.setNeedsDisplay(tRect)
+                storeTile(img, key: key)
+
+                let tRect = tileMapRect(col: col, row: row, zoom: zoom)
+                await MainActor.run {
+                    self.setNeedsDisplay(tRect)
+                }
+            } catch {
+                logger.error("Radar tile fetch failed: \(error.localizedDescription)")
+                finishPending(key)
             }
-        }.resume()
+        }
+    }
+
+    private func finishPending(_ key: String) {
+        lock.lock()
+        pending.remove(key)
+        lock.unlock()
+    }
+
+    private func storeTile(_ image: CGImage, key: String) {
+        lock.lock()
+        cache[key] = image
+        pending.remove(key)
+        lock.unlock()
     }
 
     // MARK: - Tile Math

--- a/macOS/WeatherForecastView.swift
+++ b/macOS/WeatherForecastView.swift
@@ -187,7 +187,7 @@ struct WeatherForecastSection: View {
 
 // swiftlint:disable:next type_body_length
 struct WeatherDetailView: View {
-    @ObservedObject var locationManager: LocationManager
+    var locationManager: LocationManager
     var radarService: RadarService
     @State private var frameIndex = 0
     @State private var isPlaying = false
@@ -476,7 +476,7 @@ struct WeatherDetailView: View {
                     coordinate: locationManager.coordinate,
                     radarService: radarService,
                     frameIndex: frameIndex,
-                    onPreloadComplete: { DispatchQueue.main.async { tilesReady = true } }
+                    onPreloadComplete: { Task { @MainActor in tilesReady = true } }
                 )
                 .frame(maxWidth: .infinity).frame(height: 300)
                 .cornerRadius(8).clipped()

--- a/macOS/WeatherRadarView.swift
+++ b/macOS/WeatherRadarView.swift
@@ -29,7 +29,7 @@ struct WeatherRadarSheet: View {
                     coordinate: coordinate,
                     radarService: radarService,
                     frameIndex: frameIndex,
-                    onPreloadComplete: { DispatchQueue.main.async { tilesReady = true } }
+                    onPreloadComplete: { Task { @MainActor in tilesReady = true } }
                 )
                 .frame(minWidth: 500).frame(height: 350)
                 controls
@@ -189,7 +189,7 @@ struct WeatherRadarSheet: View {
 // MARK: - Weather Card (Compact Dashboard Card)
 
 struct WeatherCard: View {
-    @ObservedObject var locationManager: LocationManager
+    var locationManager: LocationManager
     var radarService: RadarService
     var onNavigate: (SidebarItem) -> Void
 


### PR DESCRIPTION
## Summary
- migrate app-owned observable models to Swift Observation
- replace callback networking, main-queue dispatches, and timer publishers with structured concurrency
- move iOS/visionOS app device state out of global variables and into SwiftUI state
- fix battery unknown-level clamping and preserve selected HomeConnect program names

## Validation
- swiftlint --strict --config .swiftlint.yml --quiet
- xcodebuild test -project FluxHaus.xcodeproj -scheme "FluxHaus (iOS)" -destination 'platform=iOS Simulator,name=iPhone 17' CODE_SIGNING_ALLOWED=NO -quiet
- xcodebuild test -project FluxHaus.xcodeproj -scheme "VisionOS" -destination 'platform=visionOS Simulator,name=Apple Vision Pro' CODE_SIGNING_ALLOWED=NO -quiet
- xcodebuild test -project FluxHaus.xcodeproj -scheme "FluxHaus (macOS)" CODE_SIGNING_ALLOWED=NO -quiet
- xcodebuild -project FluxHaus.xcodeproj -scheme "FluxWidgetExtension" -configuration Debug -destination 'generic/platform=iOS Simulator' build CODE_SIGNING_ALLOWED=NO -quiet