### PR TITLE
Render chat transcript in a web view

### DIFF
--- a/FluxHaus.xcodeproj/project.pbxproj
+++ b/FluxHaus.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		633F094A2BBB8F8F0052C088 /* CarHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 633F09472BBB8F8F0052C088 /* CarHelper.swift */; };
 		634056CD2E47FDBA001F8278 /* Tests_iOS_SwiftTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 634056CC2E47FDBA001F8278 /* Tests_iOS_SwiftTesting.swift */; };
 		634056DC2E47FFC2001F8278 /* WhereWeAreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 634056D32E47FFC2001F8278 /* WhereWeAreTests.swift */; };
+		CTR0005000000000000000001 /* ChatTranscriptRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CTR0005000000000000000002 /* ChatTranscriptRendererTests.swift */; };
 		634056DD2E47FFC2001F8278 /* HomeConnectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 634056CF2E47FFC2001F8278 /* HomeConnectTests.swift */; };
 		634056DE2E47FFC2001F8278 /* BatteryAndWeatherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 634056CE2E47FFC2001F8278 /* BatteryAndWeatherTests.swift */; };
 		634056DF2E47FFC2001F8278 /* SharedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 634056D22E47FFC2001F8278 /* SharedTests.swift */; };
@@ -216,6 +217,10 @@
 		CB0002000000000000000002 /* ChatBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0001000000000000000001 /* ChatBubble.swift */; };
 		CB0002000000000000000003 /* ChatBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0001000000000000000001 /* ChatBubble.swift */; };
 		CB0002000000000000000004 /* ChatBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0001000000000000000001 /* ChatBubble.swift */; };
+		CWV0002000000000000000001 /* ConversationWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CWV0001000000000000000001 /* ConversationWebView.swift */; };
+		CWV0002000000000000000002 /* ConversationWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CWV0001000000000000000001 /* ConversationWebView.swift */; };
+		CWV0002000000000000000003 /* ConversationWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CWV0001000000000000000001 /* ConversationWebView.swift */; };
+		CWV0002000000000000000004 /* ConversationWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CWV0001000000000000000001 /* ConversationWebView.swift */; };
 		CSV0001000000000000000001 /* ConversationScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CSV0000000000000000000001 /* ConversationScrollView.swift */; };
 		CSV0001000000000000000002 /* ConversationScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CSV0000000000000000000001 /* ConversationScrollView.swift */; };
 		CSV0001000000000000000003 /* ConversationScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CSV0000000000000000000001 /* ConversationScrollView.swift */; };
@@ -255,6 +260,19 @@
 		MD0002000000000000000002 /* MarkdownContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = MD0001000000000000000001 /* MarkdownContentView.swift */; };
 		MD0002000000000000000003 /* MarkdownContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = MD0001000000000000000001 /* MarkdownContentView.swift */; };
 		MD0002000000000000000004 /* MarkdownContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = MD0001000000000000000001 /* MarkdownContentView.swift */; };
+		CTR0002000000000000000001 /* ChatTranscriptRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CTR0001000000000000000001 /* ChatTranscriptRenderer.swift */; };
+		CTR0002000000000000000002 /* ChatTranscriptRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CTR0001000000000000000001 /* ChatTranscriptRenderer.swift */; };
+		CTR0002000000000000000003 /* ChatTranscriptRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CTR0001000000000000000001 /* ChatTranscriptRenderer.swift */; };
+		CTR0002000000000000000004 /* ChatTranscriptRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CTR0001000000000000000001 /* ChatTranscriptRenderer.swift */; };
+		CTR0003000000000000000001 /* ChatTranscriptRenderer.html in Resources */ = {isa = PBXBuildFile; fileRef = CTR0001000000000000000002 /* ChatTranscriptRenderer.html */; };
+		CTR0003000000000000000002 /* ChatTranscriptRenderer.html in Resources */ = {isa = PBXBuildFile; fileRef = CTR0001000000000000000002 /* ChatTranscriptRenderer.html */; };
+		CTR0003000000000000000003 /* ChatTranscriptRenderer.html in Resources */ = {isa = PBXBuildFile; fileRef = CTR0001000000000000000002 /* ChatTranscriptRenderer.html */; };
+		CTR0003000000000000000004 /* ChatTranscriptRenderer.css in Resources */ = {isa = PBXBuildFile; fileRef = CTR0001000000000000000003 /* ChatTranscriptRenderer.css */; };
+		CTR0003000000000000000005 /* ChatTranscriptRenderer.css in Resources */ = {isa = PBXBuildFile; fileRef = CTR0001000000000000000003 /* ChatTranscriptRenderer.css */; };
+		CTR0003000000000000000006 /* ChatTranscriptRenderer.css in Resources */ = {isa = PBXBuildFile; fileRef = CTR0001000000000000000003 /* ChatTranscriptRenderer.css */; };
+		CTR0003000000000000000007 /* ChatTranscriptRenderer.js in Resources */ = {isa = PBXBuildFile; fileRef = CTR0001000000000000000004 /* ChatTranscriptRenderer.js */; };
+		CTR0003000000000000000008 /* ChatTranscriptRenderer.js in Resources */ = {isa = PBXBuildFile; fileRef = CTR0001000000000000000004 /* ChatTranscriptRenderer.js */; };
+		CTR0003000000000000000009 /* ChatTranscriptRenderer.js in Resources */ = {isa = PBXBuildFile; fileRef = CTR0001000000000000000004 /* ChatTranscriptRenderer.js */; };
 		MP0002000000000000000001 /* MarkdownParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = MP0001000000000000000001 /* MarkdownParser.swift */; };
 		MP0002000000000000000002 /* MarkdownParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = MP0001000000000000000001 /* MarkdownParser.swift */; };
 		MP0002000000000000000003 /* MarkdownParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = MP0001000000000000000001 /* MarkdownParser.swift */; };
@@ -369,6 +387,7 @@
 		634056D22E47FFC2001F8278 /* SharedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedTests.swift; sourceTree = "<group>"; };
 		634056D32E47FFC2001F8278 /* WhereWeAreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhereWeAreTests.swift; sourceTree = "<group>"; };
 		634056D42E47FFC2001F8278 /* WidgetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetTests.swift; sourceTree = "<group>"; };
+		CTR0005000000000000000002 /* ChatTranscriptRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTranscriptRendererTests.swift; sourceTree = "<group>"; };
 		635BD66A2B9DF8A6009CEEA9 /* Robots.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Robots.swift; sourceTree = "<group>"; };
 		635BD66F2B9DFAE1009CEEA9 /* WhereWeAre.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhereWeAre.swift; sourceTree = "<group>"; };
 		635BD6742B9E030E009CEEA9 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -437,7 +456,12 @@
 		C8CB990FC6404C8682E3BE62 /* ScooterDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScooterDetailView.swift; sourceTree = "<group>"; };
 		CB0001000000000000000001 /* ChatBubble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatBubble.swift; sourceTree = "<group>"; };
 		CEF67D2F97BC4B6C8737FCC9 /* Scooter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Scooter.swift; sourceTree = "<group>"; };
+		CTR0001000000000000000001 /* ChatTranscriptRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTranscriptRenderer.swift; sourceTree = "<group>"; };
+		CTR0001000000000000000002 /* ChatTranscriptRenderer.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = ChatTranscriptRenderer.html; sourceTree = "<group>"; };
+		CTR0001000000000000000003 /* ChatTranscriptRenderer.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = ChatTranscriptRenderer.css; sourceTree = "<group>"; };
+		CTR0001000000000000000004 /* ChatTranscriptRenderer.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = ChatTranscriptRenderer.js; sourceTree = "<group>"; };
 		CSV0000000000000000000001 /* ConversationScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationScrollView.swift; sourceTree = "<group>"; };
+		CWV0001000000000000000001 /* ConversationWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationWebView.swift; sourceTree = "<group>"; };
 		D7F4D12AFB5260CA5BD9CE33 /* CarPlayVoiceManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CarPlayVoiceManager.swift; sourceTree = "<group>"; };
 		FAAEBC8C9F79B50F67076AB6 /* WeatherHelpers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WeatherHelpers.swift; sourceTree = "<group>"; };
 		MD0001000000000000000001 /* MarkdownContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownContentView.swift; sourceTree = "<group>"; };
@@ -584,6 +608,9 @@
 				37D0A0000000000000000001 /* SuggestionChips.swift */,
 				PT0000000000000000000001 /* PrecipitationTimelineView.swift */,
 				CSV0000000000000000000001 /* ConversationScrollView.swift */,
+				CWV0001000000000000000001 /* ConversationWebView.swift */,
+				CTR0001000000000000000001 /* ChatTranscriptRenderer.swift */,
+				CTR0004000000000000000001 /* ChatWebRenderer */,
 				TI0000000000000000000001 /* TypingIndicator.swift */,
 				CB0001000000000000000001 /* ChatBubble.swift */,
 				MD0001000000000000000001 /* MarkdownContentView.swift */,
@@ -591,6 +618,16 @@
 				NS0001000000000000000001 /* NotificationSettingsView.swift */,
 			);
 			path = Shared;
+			sourceTree = "<group>";
+		};
+		CTR0004000000000000000001 /* ChatWebRenderer */ = {
+			isa = PBXGroup;
+			children = (
+				CTR0001000000000000000002 /* ChatTranscriptRenderer.html */,
+				CTR0001000000000000000003 /* ChatTranscriptRenderer.css */,
+				CTR0001000000000000000004 /* ChatTranscriptRenderer.js */,
+			);
+			path = ChatWebRenderer;
 			sourceTree = "<group>";
 		};
 		632CBC2C258682C9003E4988 /* Products */ = {
@@ -682,6 +719,7 @@
 			isa = PBXGroup;
 			children = (
 				634056CE2E47FFC2001F8278 /* BatteryAndWeatherTests.swift */,
+				CTR0005000000000000000002 /* ChatTranscriptRendererTests.swift */,
 				634056CF2E47FFC2001F8278 /* HomeConnectTests.swift */,
 				634056D02E47FFC2001F8278 /* IntegrationTests.swift */,
 				634056D12E47FFC2001F8278 /* QueryFluxTests.swift */,
@@ -952,6 +990,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				6D3A6DF0ADB0547372080998 /* Assets.xcassets in Resources */,
+				CTR0003000000000000000002 /* ChatTranscriptRenderer.html in Resources */,
+				CTR0003000000000000000005 /* ChatTranscriptRenderer.css in Resources */,
+				CTR0003000000000000000008 /* ChatTranscriptRenderer.js in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -960,6 +1001,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				632CBC51258682C9003E4988 /* Assets.xcassets in Resources */,
+				CTR0003000000000000000001 /* ChatTranscriptRenderer.html in Resources */,
+				CTR0003000000000000000004 /* ChatTranscriptRenderer.css in Resources */,
+				CTR0003000000000000000007 /* ChatTranscriptRenderer.js in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -984,6 +1028,9 @@
 			files = (
 				63DBD73C2B954216006603D0 /* Preview Assets.xcassets in Resources */,
 				63DBD7392B954216006603D0 /* Assets.xcassets in Resources */,
+				CTR0003000000000000000003 /* ChatTranscriptRenderer.html in Resources */,
+				CTR0003000000000000000006 /* ChatTranscriptRenderer.css in Resources */,
+				CTR0003000000000000000009 /* ChatTranscriptRenderer.js in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1096,6 +1143,8 @@
 				37D0A0010000000000000001 /* SuggestionChips.swift in Sources */,
 				PT0001000000000000000001 /* PrecipitationTimelineView.swift in Sources */,
 				CSV0001000000000000000001 /* ConversationScrollView.swift in Sources */,
+				CWV0002000000000000000001 /* ConversationWebView.swift in Sources */,
+				CTR0002000000000000000001 /* ChatTranscriptRenderer.swift in Sources */,
 				TI0001000000000000000001 /* TypingIndicator.swift in Sources */,
 				CB0002000000000000000001 /* ChatBubble.swift in Sources */,
 				MD0002000000000000000001 /* MarkdownContentView.swift in Sources */,
@@ -1162,6 +1211,8 @@
 				37D0A0010000000000000002 /* SuggestionChips.swift in Sources */,
 				PT0001000000000000000002 /* PrecipitationTimelineView.swift in Sources */,
 				CSV0001000000000000000002 /* ConversationScrollView.swift in Sources */,
+				CWV0002000000000000000002 /* ConversationWebView.swift in Sources */,
+				CTR0002000000000000000002 /* ChatTranscriptRenderer.swift in Sources */,
 				TI0001000000000000000002 /* TypingIndicator.swift in Sources */,
 				CB0002000000000000000002 /* ChatBubble.swift in Sources */,
 				MD0002000000000000000002 /* MarkdownContentView.swift in Sources */,
@@ -1269,6 +1320,8 @@
 				37D0A0010000000000000003 /* SuggestionChips.swift in Sources */,
 				PT0001000000000000000003 /* PrecipitationTimelineView.swift in Sources */,
 				CSV0001000000000000000003 /* ConversationScrollView.swift in Sources */,
+				CWV0002000000000000000003 /* ConversationWebView.swift in Sources */,
+				CTR0002000000000000000003 /* ChatTranscriptRenderer.swift in Sources */,
 				TI0001000000000000000003 /* TypingIndicator.swift in Sources */,
 				CB0002000000000000000003 /* ChatBubble.swift in Sources */,
 				MD0002000000000000000003 /* MarkdownContentView.swift in Sources */,
@@ -1281,6 +1334,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				63DBD7472B954216006603D0 /* VisionOSTests.swift in Sources */,
+				CTR0005000000000000000001 /* ChatTranscriptRendererTests.swift in Sources */,
 				634056DD2E47FFC2001F8278 /* HomeConnectTests.swift in Sources */,
 				634056DE2E47FFC2001F8278 /* BatteryAndWeatherTests.swift in Sources */,
 				634056DF2E47FFC2001F8278 /* SharedTests.swift in Sources */,
@@ -1345,6 +1399,8 @@
 				37D0A0010000000000000004 /* SuggestionChips.swift in Sources */,
 				PT0001000000000000000004 /* PrecipitationTimelineView.swift in Sources */,
 				CSV0001000000000000000004 /* ConversationScrollView.swift in Sources */,
+				CWV0002000000000000000004 /* ConversationWebView.swift in Sources */,
+				CTR0002000000000000000004 /* ChatTranscriptRenderer.swift in Sources */,
 				TI0001000000000000000004 /* TypingIndicator.swift in Sources */,
 				CB0002000000000000000004 /* ChatBubble.swift in Sources */,
 				MD0002000000000000000004 /* MarkdownContentView.swift in Sources */,
@@ -1386,7 +1442,7 @@
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.8;
+				MARKETING_VERSION = 1.8.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.davidjensenius.FluxHaus.Tests-macOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
@@ -1452,7 +1508,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.8;
+				MARKETING_VERSION = 1.8.10;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -1513,7 +1569,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.8;
+				MARKETING_VERSION = 1.8.10;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -1541,7 +1597,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.9;
+				MARKETING_VERSION = 1.8.10;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus;
 				PRODUCT_NAME = FluxHaus;
 				SDKROOT = iphoneos;
@@ -1574,7 +1630,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.9;
+				MARKETING_VERSION = 1.8.10;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus;
 				PRODUCT_NAME = FluxHaus;
 				SDKROOT = iphoneos;
@@ -1603,7 +1659,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.8;
+				MARKETING_VERSION = 1.8.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.davidjensenius.Tests-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1630,7 +1686,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.8;
+				MARKETING_VERSION = 1.8.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.davidjensenius.Tests-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1669,7 +1725,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.8.9;
+				MARKETING_VERSION = 1.8.10;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus.FluxWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1708,7 +1764,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.8.9;
+				MARKETING_VERSION = 1.8.10;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus.FluxWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1745,7 +1801,7 @@
 					"@executable_path/Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.8.9;
+				MARKETING_VERSION = 1.8.10;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus;
 				PRODUCT_MODULE_NAME = FluxHaus;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1783,7 +1839,7 @@
 					"@executable_path/Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.8.9;
+				MARKETING_VERSION = 1.8.10;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus;
 				PRODUCT_MODULE_NAME = FluxHaus;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1809,7 +1865,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.8.8;
+				MARKETING_VERSION = 1.8.10;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jensenius.fluxhaus.VisionOSTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = xros;
@@ -1835,7 +1891,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.8.8;
+				MARKETING_VERSION = 1.8.10;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jensenius.fluxhaus.VisionOSTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = xros;
@@ -1882,7 +1938,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.9;
+				MARKETING_VERSION = 1.8.10;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus;
 				PRODUCT_NAME = FluxHaus;
 				SDKROOT = macosx;
@@ -1922,7 +1978,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.9;
+				MARKETING_VERSION = 1.8.10;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus;
 				PRODUCT_NAME = FluxHaus;
 				SDKROOT = macosx;
@@ -1938,7 +1994,7 @@
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.8;
+				MARKETING_VERSION = 1.8.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.davidjensenius.FluxHaus.Tests-macOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;

--- a/Shared/ChatTranscriptRenderer.swift
+++ b/Shared/ChatTranscriptRenderer.swift
@@ -1,0 +1,68 @@
+//
+//  ChatTranscriptRenderer.swift
+//  FluxHaus
+//
+//  Created by Copilot on 2026-05-22.
+//
+
+import Foundation
+
+enum ChatTranscriptRenderer {
+    private static let defaultsKey = "ChatTranscriptWebRendererEnabled"
+
+    static var usesWebTranscript: Bool {
+        if UserDefaults.standard.object(forKey: defaultsKey) == nil {
+            return true
+        }
+        return UserDefaults.standard.bool(forKey: defaultsKey)
+    }
+}
+
+struct ChatTranscriptSnapshot: Encodable {
+    let conversationId: String
+    let messages: [ChatTranscriptMessage]
+    let isLoading: Bool
+
+    init(conversationId: String, messages: [ChatMessage], isLoading: Bool, playingMessageId: UUID?) {
+        self.conversationId = conversationId
+        self.messages = messages.map {
+            ChatTranscriptMessage(message: $0, isPlaying: $0.id == playingMessageId)
+        }
+        self.isLoading = isLoading
+    }
+}
+
+struct ChatTranscriptMessage: Encodable {
+    let id: String
+    let role: String
+    let content: String
+    let isProgress: Bool
+    let isVoice: Bool
+    let hasAudio: Bool
+    let isPlaying: Bool
+    let images: [ChatTranscriptImage]
+
+    init(message: ChatMessage, isPlaying: Bool) {
+        id = message.id.uuidString
+        role = message.role.rawValue
+        content = message.content
+        isProgress = message.isProgress
+        isVoice = message.isVoice
+        hasAudio = message.audioData != nil
+        self.isPlaying = isPlaying
+        images = message.images.compactMap(ChatTranscriptImage.init(image:))
+    }
+}
+
+struct ChatTranscriptImage: Encodable {
+    let mediaType: String
+    let dataURL: String
+
+    init?(image: ChatImage) {
+        let allowedTypes = ["image/jpeg", "image/png", "image/gif", "image/webp", "image/heic"]
+        guard allowedTypes.contains(image.mediaType.lowercased()),
+              Data(base64Encoded: image.base64) != nil else { return nil }
+        mediaType = image.mediaType.lowercased()
+        dataURL = "data:\(mediaType);base64,\(image.base64)"
+    }
+}

--- a/Shared/ChatTranscriptRenderer.swift
+++ b/Shared/ChatTranscriptRenderer.swift
@@ -16,6 +16,10 @@ enum ChatTranscriptRenderer {
         }
         return UserDefaults.standard.bool(forKey: defaultsKey)
     }
+
+    static var isAvailable: Bool {
+        Bundle.main.url(forResource: "ChatTranscriptRenderer", withExtension: "html") != nil
+    }
 }
 
 struct ChatTranscriptSnapshot: Encodable {
@@ -57,10 +61,12 @@ struct ChatTranscriptMessage: Encodable {
 struct ChatTranscriptImage: Encodable {
     let mediaType: String
     let dataURL: String
+    private static let allowedTypes: Set<String> = [
+        "image/jpeg", "image/png", "image/gif", "image/webp", "image/heic"
+    ]
 
     init?(image: ChatImage) {
-        let allowedTypes = ["image/jpeg", "image/png", "image/gif", "image/webp", "image/heic"]
-        guard allowedTypes.contains(image.mediaType.lowercased()),
+        guard Self.allowedTypes.contains(image.mediaType.lowercased()),
               Data(base64Encoded: image.base64) != nil else { return nil }
         mediaType = image.mediaType.lowercased()
         dataURL = "data:\(mediaType);base64,\(image.base64)"

--- a/Shared/ChatWebRenderer/ChatTranscriptRenderer.css
+++ b/Shared/ChatWebRenderer/ChatTranscriptRenderer.css
@@ -1,0 +1,309 @@
+:root {
+  color-scheme: light dark;
+  --scale: 1;
+  --background: transparent;
+  --text: #4c4f69;
+  --muted: #6c6f85;
+  --accent: #fe640b;
+  --user-bg: #fe640b;
+  --user-text: #eff1f5;
+  --assistant-bg: #e6e9ef;
+  --error-bg: rgba(210, 15, 57, 0.15);
+  --error-text: #d20f39;
+  --code-bg: rgba(76, 79, 105, 0.08);
+  --border: rgba(76, 79, 105, 0.18);
+  --blockquote-border: rgba(254, 100, 11, 0.55);
+  --radius: 18px;
+  --font-size: calc(18px * var(--scale));
+  --small-size: calc(14px * var(--scale));
+}
+
+html,
+body {
+  background: transparent;
+  color: var(--text);
+  font: var(--font-size) -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
+  height: 100%;
+  margin: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  -webkit-text-size-adjust: 100%;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+a {
+  color: var(--accent);
+  cursor: pointer;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+#transcript {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-height: 100%;
+  padding: 12px;
+}
+
+.row {
+  display: flex;
+  width: 100%;
+}
+
+.row.user {
+  justify-content: flex-end;
+}
+
+.row.assistant,
+.row.error,
+.row.progress {
+  justify-content: flex-start;
+}
+
+.bubble {
+  border-radius: var(--radius);
+  line-height: 1.42;
+  max-width: min(78%, 860px);
+  overflow-wrap: anywhere;
+  padding: 12px 14px;
+  user-select: text;
+  -webkit-user-select: text;
+}
+
+.user .bubble {
+  background: var(--user-bg);
+  color: var(--user-text);
+}
+
+.assistant .bubble {
+  background: var(--assistant-bg);
+  color: var(--text);
+}
+
+.error .bubble {
+  background: var(--error-bg);
+  color: var(--error-text);
+}
+
+.progress .bubble {
+  background: transparent;
+  color: var(--muted);
+  font-size: var(--small-size);
+  font-style: italic;
+  padding: 6px 8px;
+}
+
+.content > :first-child {
+  margin-top: 0;
+}
+
+.content > :last-child {
+  margin-bottom: 0;
+}
+
+p,
+ul,
+ol,
+blockquote,
+pre,
+table {
+  margin: 0.55em 0;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  line-height: 1.2;
+  margin: 0.7em 0 0.35em;
+}
+
+h1 { font-size: 1.35em; }
+h2 { font-size: 1.22em; }
+h3 { font-size: 1.1em; }
+
+ul,
+ol {
+  padding-left: 1.35em;
+}
+
+li + li {
+  margin-top: 0.25em;
+}
+
+blockquote {
+  border-left: 3px solid var(--blockquote-border);
+  color: var(--muted);
+  margin-left: 0;
+  padding-left: 0.75em;
+}
+
+code {
+  background: var(--code-bg);
+  border-radius: 5px;
+  font-family: "SF Mono", ui-monospace, Menlo, Consolas, monospace;
+  font-size: 0.88em;
+  padding: 0.12em 0.3em;
+}
+
+pre {
+  background: var(--code-bg);
+  border-radius: 8px;
+  overflow-x: auto;
+  padding: 0.75em;
+}
+
+pre code {
+  background: transparent;
+  border-radius: 0;
+  display: block;
+  padding: 0;
+  white-space: pre;
+}
+
+table {
+  border-collapse: collapse;
+  display: block;
+  overflow-x: auto;
+  width: 100%;
+}
+
+th,
+td {
+  border: 1px solid var(--border);
+  padding: 0.4em 0.6em;
+  text-align: left;
+}
+
+th {
+  background: var(--code-bg);
+  font-weight: 650;
+}
+
+.image-grid {
+  display: grid;
+  gap: 4px;
+  margin-bottom: 8px;
+}
+
+.image-grid.one {
+  grid-template-columns: 1fr;
+}
+
+.image-grid.many {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.attachment {
+  border-radius: 12px;
+  max-height: 220px;
+  max-width: 100%;
+  object-fit: contain;
+  overflow: hidden;
+}
+
+.blocked-image {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--muted);
+  display: inline-block;
+  font-size: var(--small-size);
+  padding: 0.45em 0.65em;
+}
+
+.voice-button {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  color: currentColor;
+  cursor: pointer;
+  display: inline-flex;
+  font: inherit;
+  gap: 4px;
+  margin-top: 6px;
+  opacity: 0.82;
+  padding: 0;
+}
+
+.typing {
+  align-items: center;
+  color: var(--muted);
+  display: flex;
+  font-size: var(--small-size);
+  gap: 6px;
+  padding: 0 8px 4px;
+}
+
+.dots {
+  display: inline-flex;
+  gap: 3px;
+}
+
+.dots span {
+  animation: pulse 1.2s infinite ease-in-out;
+  background: currentColor;
+  border-radius: 50%;
+  height: 5px;
+  width: 5px;
+}
+
+.dots span:nth-child(2) { animation-delay: 0.15s; }
+.dots span:nth-child(3) { animation-delay: 0.3s; }
+
+@keyframes pulse {
+  0%, 80%, 100% { opacity: 0.35; transform: scale(0.85); }
+  40% { opacity: 1; transform: scale(1); }
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --text: #cdd6f4;
+    --muted: #a6adc8;
+    --accent: #fab387;
+    --user-bg: #fab387;
+    --user-text: #1e1e2e;
+    --assistant-bg: #181825;
+    --error-bg: rgba(243, 139, 168, 0.15);
+    --error-text: #f38ba8;
+    --code-bg: rgba(205, 214, 244, 0.09);
+    --border: rgba(205, 214, 244, 0.18);
+    --blockquote-border: rgba(250, 179, 135, 0.55);
+  }
+}
+
+:root[data-scheme="dark"] {
+  --text: #cdd6f4;
+  --muted: #a6adc8;
+  --accent: #fab387;
+  --user-bg: #fab387;
+  --user-text: #1e1e2e;
+  --assistant-bg: #181825;
+  --error-bg: rgba(243, 139, 168, 0.15);
+  --error-text: #f38ba8;
+  --code-bg: rgba(205, 214, 244, 0.09);
+  --border: rgba(205, 214, 244, 0.18);
+  --blockquote-border: rgba(250, 179, 135, 0.55);
+}
+
+:root[data-scheme="light"] {
+  --text: #4c4f69;
+  --muted: #6c6f85;
+  --accent: #fe640b;
+  --user-bg: #fe640b;
+  --user-text: #eff1f5;
+  --assistant-bg: #e6e9ef;
+  --error-bg: rgba(210, 15, 57, 0.15);
+  --error-text: #d20f39;
+  --code-bg: rgba(76, 79, 105, 0.08);
+  --border: rgba(76, 79, 105, 0.18);
+  --blockquote-border: rgba(254, 100, 11, 0.55);
+}

--- a/Shared/ChatWebRenderer/ChatTranscriptRenderer.html
+++ b/Shared/ChatWebRenderer/ChatTranscriptRenderer.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta
+    name="viewport"
+    content="width=device-width, initial-scale=1, viewport-fit=cover"
+  >
+  <meta
+    http-equiv="Content-Security-Policy"
+    content="default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src data:; base-uri 'none'; form-action 'none'"
+  >
+  <link rel="stylesheet" href="ChatTranscriptRenderer.css">
+  <title>FluxHaus Chat</title>
+</head>
+<body>
+  <main id="transcript" aria-label="Chat transcript"></main>
+  <script src="ChatTranscriptRenderer.js"></script>
+</body>
+</html>

--- a/Shared/ChatWebRenderer/ChatTranscriptRenderer.js
+++ b/Shared/ChatWebRenderer/ChatTranscriptRenderer.js
@@ -1,0 +1,274 @@
+(function () {
+  "use strict";
+
+  const bridge = window.webkit && window.webkit.messageHandlers
+    ? window.webkit.messageHandlers.fluxHausChat
+    : null;
+  const transcript = document.getElementById("transcript");
+  let lastMessageId = null;
+
+  function post(message) {
+    if (bridge) bridge.postMessage(message);
+  }
+
+  function escapeHTML(value) {
+    return String(value ?? "")
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
+  }
+
+  function escapeAttribute(value) {
+    return escapeHTML(value).replace(/`/g, "&#96;");
+  }
+
+  function safeURL(value) {
+    try {
+      const url = new URL(String(value), "https://fluxhaus.local");
+      if (["http:", "https:", "mailto:"].includes(url.protocol)) return url.href;
+    } catch (_) {}
+    return null;
+  }
+
+  function inlineMarkdown(text) {
+    let html = escapeHTML(text);
+    html = html.replace(/`([^`]+)`/g, "<code>$1</code>");
+    html = html.replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>");
+    html = html.replace(/\*([^*]+)\*/g, "<em>$1</em>");
+    html = html.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_match, label, href) => {
+      const url = safeURL(href);
+      if (!url) return escapeHTML(label);
+      return `<a href="${escapeAttribute(url)}" target="_blank" rel="noopener">${label}</a>`;
+    });
+    return html;
+  }
+
+  function tableRow(line, tag) {
+    const cells = line.replace(/^\|/, "").replace(/\|$/, "").split("|");
+    return `<tr>${cells.map((cell) => `<${tag}>${inlineMarkdown(cell.trim())}</${tag}>`).join("")}</tr>`;
+  }
+
+  function isTableSeparator(line) {
+    const stripped = line.trim().replace(/^\|/, "").replace(/\|$/, "");
+    if (!stripped.includes("-")) return false;
+    return stripped.split("|").every((part) => /^:?-{3,}:?$/.test(part.trim()));
+  }
+
+  function markdownToHTML(markdown) {
+    const lines = String(markdown ?? "").split(/\r?\n/);
+    const blocks = [];
+    let index = 0;
+
+    while (index < lines.length) {
+      const raw = lines[index];
+      const trimmed = raw.trim();
+      if (!trimmed) {
+        index += 1;
+        continue;
+      }
+
+      if (trimmed.startsWith("```")) {
+        const language = escapeHTML(trimmed.slice(3).trim());
+        const code = [];
+        index += 1;
+        while (index < lines.length && !lines[index].trim().startsWith("```")) {
+          code.push(lines[index]);
+          index += 1;
+        }
+        if (index < lines.length) index += 1;
+        const label = language ? `<div class="code-language">${language}</div>` : "";
+        blocks.push(`${label}<pre><code>${escapeHTML(code.join("\n"))}</code></pre>`);
+        continue;
+      }
+
+      const heading = /^(#{1,6})\s+(.+)$/.exec(trimmed);
+      if (heading) {
+        const level = heading[1].length;
+        blocks.push(`<h${level}>${inlineMarkdown(heading[2])}</h${level}>`);
+        index += 1;
+        continue;
+      }
+
+      if (/^([-*_])(\s*\1){2,}$/.test(trimmed)) {
+        blocks.push("<hr>");
+        index += 1;
+        continue;
+      }
+
+      if (trimmed.startsWith(">")) {
+        const quote = [];
+        while (index < lines.length && lines[index].trim().startsWith(">")) {
+          quote.push(lines[index].trim().replace(/^>\s?/, ""));
+          index += 1;
+        }
+        blocks.push(`<blockquote>${inlineMarkdown(quote.join("\n"))}</blockquote>`);
+        continue;
+      }
+
+      if (trimmed.includes("|") && index + 1 < lines.length && isTableSeparator(lines[index + 1])) {
+        const header = tableRow(trimmed, "th");
+        const rows = [];
+        index += 2;
+        while (index < lines.length && lines[index].trim().includes("|")) {
+          rows.push(tableRow(lines[index].trim(), "td"));
+          index += 1;
+        }
+        blocks.push(`<table><thead>${header}</thead><tbody>${rows.join("")}</tbody></table>`);
+        continue;
+      }
+
+      if (/^[-*•]\s+/.test(trimmed) || /^\d+\.\s+/.test(trimmed)) {
+        const ordered = /^\d+\.\s+/.test(trimmed);
+        const items = [];
+        while (index < lines.length) {
+          const item = lines[index].trim();
+          const match = ordered ? /^\d+\.\s+(.+)$/.exec(item) : /^[-*•]\s+(.+)$/.exec(item);
+          if (!match) break;
+          items.push(`<li>${inlineMarkdown(match[1])}</li>`);
+          index += 1;
+        }
+        blocks.push(`<${ordered ? "ol" : "ul"}>${items.join("")}</${ordered ? "ol" : "ul"}>`);
+        continue;
+      }
+
+      const paragraph = [];
+      while (index < lines.length) {
+        const next = lines[index].trim();
+        if (!next || next.startsWith("```") || next.startsWith("#") || next.startsWith(">") ||
+          /^[-*•]\s+/.test(next) || /^\d+\.\s+/.test(next)) {
+          break;
+        }
+        paragraph.push(next);
+        index += 1;
+      }
+      blocks.push(`<p>${inlineMarkdown(paragraph.join(" "))}</p>`);
+    }
+
+    return sanitizeHTML(blocks.join(""));
+  }
+
+  function sanitizeHTML(html) {
+    const template = document.createElement("template");
+    template.innerHTML = html;
+    const allowedTags = new Set([
+      "A", "BLOCKQUOTE", "BR", "CODE", "DIV", "EM", "H1", "H2", "H3", "H4",
+      "H5", "H6", "HR", "LI", "OL", "P", "PRE", "SPAN", "STRONG", "TABLE",
+      "TBODY", "TD", "TH", "THEAD", "TR", "UL"
+    ]);
+    const walker = document.createTreeWalker(template.content, NodeFilter.SHOW_ELEMENT);
+    const removals = [];
+    while (walker.nextNode()) {
+      const node = walker.currentNode;
+      if (!allowedTags.has(node.tagName)) {
+        removals.push(node);
+        continue;
+      }
+      for (const attribute of Array.from(node.attributes)) {
+        const name = attribute.name.toLowerCase();
+        if (name.startsWith("on")) {
+          node.removeAttribute(attribute.name);
+        } else if (name === "href") {
+          const url = safeURL(attribute.value);
+          if (url) {
+            node.setAttribute("href", url);
+            node.setAttribute("target", "_blank");
+            node.setAttribute("rel", "noopener");
+          } else {
+            node.removeAttribute(attribute.name);
+          }
+        } else if (!["class", "target", "rel"].includes(name)) {
+          node.removeAttribute(attribute.name);
+        }
+      }
+    }
+    removals.forEach((node) => node.replaceWith(document.createTextNode(node.textContent || "")));
+    return template.innerHTML;
+  }
+
+  function textContent(message) {
+    const content = escapeHTML(message.content);
+    return content.replace(/\n/g, "<br>");
+  }
+
+  function messageContent(message) {
+    if (message.role === "assistant" && !message.isProgress) return markdownToHTML(message.content);
+    return textContent(message);
+  }
+
+  function imageGrid(images) {
+    if (!images || images.length === 0) return "";
+    const cls = images.length === 1 ? "one" : "many";
+    return `<div class="image-grid ${cls}">${images.map((image) => {
+      if (!/^data:image\/(jpeg|png|gif|webp|heic);base64,/.test(image.dataURL)) return "";
+      return `<img class="attachment" alt="Attached image" src="${escapeAttribute(image.dataURL)}">`;
+    }).join("")}</div>`;
+  }
+
+  function voiceButton(message) {
+    if (!message.hasAudio) return "";
+    const label = message.isPlaying ? "Stop" : "Play";
+    const symbol = message.isPlaying ? "■" : "▶";
+    return `<button class="voice-button" data-action="toggle-audio" data-message-id="${escapeAttribute(message.id)}">
+      <span aria-hidden="true">${symbol}</span><span>${label}</span>
+    </button>`;
+  }
+
+  function renderMessage(message) {
+    const role = message.isProgress ? "progress" : message.role;
+    return `<article class="row ${escapeAttribute(role)}" data-message-id="${escapeAttribute(message.id)}">
+      <div class="bubble">
+        ${imageGrid(message.images)}
+        <div class="content">${messageContent(message)}</div>
+        ${voiceButton(message)}
+      </div>
+    </article>`;
+  }
+
+  function typingIndicator() {
+    return `<div class="typing" aria-live="polite">
+      <span>Assistant is thinking</span>
+      <span class="dots" aria-hidden="true"><span></span><span></span><span></span></span>
+    </div>`;
+  }
+
+  function shouldStickToBottom() {
+    return window.innerHeight + window.scrollY >= document.documentElement.scrollHeight - 80;
+  }
+
+  function scrollToBottom() {
+    window.requestAnimationFrame(() => window.scrollTo(0, document.documentElement.scrollHeight));
+  }
+
+  window.FluxHausChat = {
+    setAppearance(appearance) {
+      document.documentElement.dataset.scheme = appearance.scheme;
+      document.documentElement.style.setProperty("--scale", String(appearance.scale || 1));
+    },
+    render(snapshot) {
+      const nextLast = snapshot.messages[snapshot.messages.length - 1]?.id || null;
+      const stick = shouldStickToBottom() || lastMessageId !== nextLast;
+      transcript.innerHTML = snapshot.messages.map(renderMessage).join("") +
+        (snapshot.isLoading ? typingIndicator() : "");
+      lastMessageId = nextLast;
+      if (stick) scrollToBottom();
+    }
+  };
+
+  document.addEventListener("click", (event) => {
+    const audioButton = event.target.closest("[data-action='toggle-audio']");
+    if (audioButton) {
+      event.preventDefault();
+      post({ type: "toggleAudio", messageId: audioButton.dataset.messageId });
+      return;
+    }
+    const link = event.target.closest("a[href]");
+    if (link) {
+      event.preventDefault();
+      post({ type: "openLink", url: link.href });
+    }
+  });
+
+  window.addEventListener("load", () => post({ type: "ready" }));
+})();

--- a/Shared/ChatWebRenderer/ChatTranscriptRenderer.js
+++ b/Shared/ChatWebRenderer/ChatTranscriptRenderer.js
@@ -26,7 +26,7 @@
 
   function safeURL(value) {
     try {
-      const url = new URL(String(value), "https://fluxhaus.local");
+      const url = new URL(String(value));
       if (["http:", "https:", "mailto:"].includes(url.protocol)) return url.href;
     } catch (_) {}
     return null;

--- a/Shared/ConversationScrollView.swift
+++ b/Shared/ConversationScrollView.swift
@@ -25,7 +25,7 @@ struct ConversationScrollView: View {
     var body: some View {
         let msgs = convMessages
         return Group {
-            if ChatTranscriptRenderer.usesWebTranscript {
+            if ChatTranscriptRenderer.usesWebTranscript && ChatTranscriptRenderer.isAvailable {
                 ConversationWebView(convId: convId, chat: chat)
             } else {
                 nativeTranscript(messages: msgs)

--- a/Shared/ConversationScrollView.swift
+++ b/Shared/ConversationScrollView.swift
@@ -24,7 +24,17 @@ struct ConversationScrollView: View {
 
     var body: some View {
         let msgs = convMessages
-        return ScrollView {
+        return Group {
+            if ChatTranscriptRenderer.usesWebTranscript {
+                ConversationWebView(convId: convId, chat: chat)
+            } else {
+                nativeTranscript(messages: msgs)
+            }
+        }
+    }
+
+    private func nativeTranscript(messages msgs: [ChatMessage]) -> some View {
+        ScrollView {
             LazyVStack(spacing: 12) {
                 ForEach(msgs) { message in
                     ChatBubble(
@@ -53,7 +63,7 @@ struct ConversationScrollView: View {
         .scrollPosition($scrollPosition)
         .task(id: convId) {
             // Pre-warm the markdown cache so MarkdownContentView finds hits immediately.
-            warmMarkdownCache(for: convMessages.map(\.content))
+            warmMarkdownCache(for: msgs.map(\.content))
             scrollPosition = ScrollPosition()
             try? await Task.sleep(for: .milliseconds(32))
             scrollPosition.scrollTo(edge: .bottom)

--- a/Shared/ConversationWebView.swift
+++ b/Shared/ConversationWebView.swift
@@ -1,0 +1,331 @@
+//
+//  ConversationWebView.swift
+//  FluxHaus
+//
+//  Created by Copilot on 2026-05-22.
+//
+
+import SwiftUI
+import WebKit
+
+#if canImport(UIKit)
+import UIKit
+#elseif canImport(AppKit)
+import AppKit
+#endif
+
+struct ConversationWebView: View {
+    let convId: String
+    @Bindable var chat: Chat
+    @Environment(\.openURL) private var openURL
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
+    private var snapshot: ChatTranscriptSnapshot {
+        ChatTranscriptSnapshot(
+            conversationId: convId,
+            messages: chat.messages(for: convId),
+            isLoading: chat.isLoading,
+            playingMessageId: chat.playingMessageId
+        )
+    }
+
+    var body: some View {
+        ChatTranscriptWebRepresentable(
+            snapshot: snapshot,
+            appearance: ChatTranscriptAppearance(
+                colorScheme: colorScheme,
+                dynamicTypeSize: dynamicTypeSize
+            ),
+            onOpenURL: { openURL($0) },
+            onPlayAudio: { messageId in
+                guard let message = chat.messages(for: convId).first(where: {
+                    $0.id.uuidString == messageId
+                }) else { return }
+                if chat.playingMessageId == message.id {
+                    chat.stopPlayback()
+                } else {
+                    chat.playAudio(for: message)
+                }
+            }
+        )
+        .background(Theme.Colors.background)
+        .accessibilityLabel("Chat transcript")
+    }
+}
+
+private struct ChatTranscriptAppearance: Encodable, Equatable {
+    let scheme: String
+    let scale: Double
+    private static let scaleValues: [(DynamicTypeSize, Double)] = [
+        (.xSmall, 0.88),
+        (.small, 0.94),
+        (.medium, 1.0),
+        (.large, 1.06),
+        (.xLarge, 1.12),
+        (.xxLarge, 1.18),
+        (.xxxLarge, 1.26),
+        (.accessibility1, 1.35),
+        (.accessibility2, 1.48),
+        (.accessibility3, 1.62),
+        (.accessibility4, 1.78),
+        (.accessibility5, 1.95)
+    ]
+
+    init(colorScheme: ColorScheme, dynamicTypeSize: DynamicTypeSize) {
+        scheme = colorScheme == .dark ? "dark" : "light"
+        scale = Self.dynamicTypeScale(for: dynamicTypeSize)
+    }
+
+    private static func dynamicTypeScale(for size: DynamicTypeSize) -> Double {
+        Self.scaleValues.first { $0.0 == size }?.1 ?? 1.0
+    }
+}
+
+@MainActor
+private struct ChatTranscriptWebRepresentable {
+    let snapshot: ChatTranscriptSnapshot
+    let appearance: ChatTranscriptAppearance
+    let onOpenURL: (URL) -> Void
+    let onPlayAudio: (String) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onOpenURL: onOpenURL, onPlayAudio: onPlayAudio)
+    }
+
+    fileprivate func configure(_ webView: WKWebView) {
+        webView.allowsBackForwardNavigationGestures = false
+        #if canImport(UIKit)
+        webView.isOpaque = false
+        webView.backgroundColor = .clear
+        webView.scrollView.backgroundColor = .clear
+        #elseif canImport(AppKit)
+        webView.setValue(false, forKey: "drawsBackground")
+        #endif
+    }
+
+    fileprivate func loadRenderer(into webView: WKWebView, coordinator: Coordinator) {
+        guard let url = Bundle.main.url(
+            forResource: "ChatTranscriptRenderer", withExtension: "html"
+        ) else {
+            coordinator.isReady = true
+            coordinator.send(snapshot: snapshot, appearance: appearance, to: webView)
+            return
+        }
+        webView.loadFileURL(url, allowingReadAccessTo: url.deletingLastPathComponent())
+    }
+}
+
+#if canImport(UIKit)
+extension ChatTranscriptWebRepresentable: UIViewRepresentable {
+    func makeUIView(context: Context) -> WKWebView {
+        let handler = WeakScriptHandler()
+        let webView = WKWebView(frame: .zero, configuration: Self.configuration(handler: handler))
+        webView.navigationDelegate = context.coordinator
+        webView.uiDelegate = context.coordinator
+        context.coordinator.attach(webView: webView, handler: handler)
+        configure(webView)
+        loadRenderer(into: webView, coordinator: context.coordinator)
+        return webView
+    }
+
+    func updateUIView(_ webView: WKWebView, context: Context) {
+        context.coordinator.updateCallbacks(onOpenURL: onOpenURL, onPlayAudio: onPlayAudio)
+        context.coordinator.send(snapshot: snapshot, appearance: appearance, to: webView)
+    }
+
+    static func dismantleUIView(_ webView: WKWebView, coordinator: Coordinator) {
+        coordinator.dismantle()
+    }
+}
+#elseif canImport(AppKit)
+extension ChatTranscriptWebRepresentable: NSViewRepresentable {
+    func makeNSView(context: Context) -> WKWebView {
+        let handler = WeakScriptHandler()
+        let webView = WKWebView(frame: .zero, configuration: Self.configuration(handler: handler))
+        webView.navigationDelegate = context.coordinator
+        webView.uiDelegate = context.coordinator
+        context.coordinator.attach(webView: webView, handler: handler)
+        configure(webView)
+        loadRenderer(into: webView, coordinator: context.coordinator)
+        return webView
+    }
+
+    func updateNSView(_ webView: WKWebView, context: Context) {
+        context.coordinator.updateCallbacks(onOpenURL: onOpenURL, onPlayAudio: onPlayAudio)
+        context.coordinator.send(snapshot: snapshot, appearance: appearance, to: webView)
+    }
+
+    static func dismantleNSView(_ webView: WKWebView, coordinator: Coordinator) {
+        coordinator.dismantle()
+    }
+}
+#endif
+
+@MainActor
+private extension ChatTranscriptWebRepresentable {
+    #if !targetEnvironment(macCatalyst)
+    static let processPool = WKProcessPool()
+    #endif
+
+    static func configuration(handler: WeakScriptHandler) -> WKWebViewConfiguration {
+        let config = WKWebViewConfiguration()
+        #if !targetEnvironment(macCatalyst)
+        config.processPool = processPool
+        #endif
+        let controller = WKUserContentController()
+        controller.add(handler, name: Coordinator.messageName)
+        config.userContentController = controller
+        config.defaultWebpagePreferences.allowsContentJavaScript = true
+        return config
+    }
+}
+
+@MainActor
+private final class WeakScriptHandler: NSObject, WKScriptMessageHandler {
+    weak var delegate: WKScriptMessageHandler?
+
+    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+        delegate?.userContentController(userContentController, didReceive: message)
+    }
+}
+
+extension ChatTranscriptWebRepresentable {
+    @MainActor
+    final class Coordinator: NSObject, WKNavigationDelegate, WKUIDelegate, WKScriptMessageHandler {
+        static let messageName = "fluxHausChat"
+
+        weak var webView: WKWebView?
+        var isReady = false
+        private var weakHandler: WeakScriptHandler?
+        private var pendingJSON: String?
+        private var lastJSON: String?
+        private var lastAppearanceJSON: String?
+        private var onOpenURL: (URL) -> Void
+        private var onPlayAudio: (String) -> Void
+
+        init(onOpenURL: @escaping (URL) -> Void, onPlayAudio: @escaping (String) -> Void) {
+            self.onOpenURL = onOpenURL
+            self.onPlayAudio = onPlayAudio
+            super.init()
+        }
+
+        func attach(webView: WKWebView, handler: WeakScriptHandler) {
+            self.webView = webView
+            weakHandler = handler
+            handler.delegate = self
+        }
+
+        func updateCallbacks(
+            onOpenURL: @escaping (URL) -> Void,
+            onPlayAudio: @escaping (String) -> Void
+        ) {
+            self.onOpenURL = onOpenURL
+            self.onPlayAudio = onPlayAudio
+        }
+
+        func send(
+            snapshot: ChatTranscriptSnapshot,
+            appearance: ChatTranscriptAppearance,
+            to webView: WKWebView
+        ) {
+            guard let json = encode(snapshot),
+                  let appearanceJSON = encode(appearance) else { return }
+            guard isReady else {
+                pendingJSON = json
+                lastAppearanceJSON = appearanceJSON
+                return
+            }
+            if appearanceJSON != lastAppearanceJSON {
+                evaluate("window.FluxHausChat.setAppearance(\(appearanceJSON));", in: webView)
+                lastAppearanceJSON = appearanceJSON
+            }
+            guard json != lastJSON else { return }
+            evaluate("window.FluxHausChat.render(\(json));", in: webView)
+            lastJSON = json
+        }
+
+        func userContentController(
+            _ userContentController: WKUserContentController,
+            didReceive message: WKScriptMessage
+        ) {
+            guard let body = message.body as? [String: Any],
+                  let type = body["type"] as? String else { return }
+            switch type {
+            case "ready":
+                isReady = true
+                if let webView, let pendingJSON {
+                    if let appearanceJSON = lastAppearanceJSON {
+                        evaluate("window.FluxHausChat.setAppearance(\(appearanceJSON));", in: webView)
+                    }
+                    evaluate("window.FluxHausChat.render(\(pendingJSON));", in: webView)
+                    lastJSON = pendingJSON
+                    self.pendingJSON = nil
+                }
+            case "openLink":
+                if let value = body["url"] as? String,
+                   let url = URL(string: value),
+                   allowedExternalURL(url) {
+                    onOpenURL(url)
+                }
+            case "toggleAudio":
+                if let id = body["messageId"] as? String {
+                    onPlayAudio(id)
+                }
+            default:
+                break
+            }
+        }
+
+        func webView(
+            _ webView: WKWebView,
+            decidePolicyFor navigationAction: WKNavigationAction,
+            decisionHandler: @escaping @MainActor @Sendable (WKNavigationActionPolicy) -> Void
+        ) {
+            guard navigationAction.navigationType != .other else {
+                decisionHandler(.allow)
+                return
+            }
+            if let url = navigationAction.request.url, allowedExternalURL(url) {
+                onOpenURL(url)
+            }
+            decisionHandler(.cancel)
+        }
+
+        func webView(
+            _ webView: WKWebView,
+            createWebViewWith configuration: WKWebViewConfiguration,
+            for navigationAction: WKNavigationAction,
+            windowFeatures: WKWindowFeatures
+        ) -> WKWebView? {
+            if let url = navigationAction.request.url, allowedExternalURL(url) {
+                onOpenURL(url)
+            }
+            return nil
+        }
+
+        func dismantle() {
+            webView?.navigationDelegate = nil
+            webView?.uiDelegate = nil
+            webView?.configuration.userContentController.removeScriptMessageHandler(
+                forName: Self.messageName
+            )
+            webView = nil
+            weakHandler?.delegate = nil
+        }
+
+        private func encode<T: Encodable>(_ value: T) -> String? {
+            guard let data = try? JSONEncoder().encode(value) else { return nil }
+            return String(data: data, encoding: .utf8)
+        }
+
+        private func evaluate(_ script: String, in webView: WKWebView) {
+            webView.evaluateJavaScript(script)
+        }
+
+        private func allowedExternalURL(_ url: URL) -> Bool {
+            guard let scheme = url.scheme?.lowercased() else { return false }
+            return ["http", "https", "mailto"].contains(scheme)
+        }
+    }
+}

--- a/Shared/ConversationWebView.swift
+++ b/Shared/ConversationWebView.swift
@@ -108,8 +108,8 @@ private struct ChatTranscriptWebRepresentable {
         guard let url = Bundle.main.url(
             forResource: "ChatTranscriptRenderer", withExtension: "html"
         ) else {
-            coordinator.isReady = true
-            coordinator.send(snapshot: snapshot, appearance: appearance, to: webView)
+            let message = "Chat transcript renderer is missing from the app bundle."
+            webView.loadHTMLString("<!doctype html><p>\(message)</p>", baseURL: nil)
             return
         }
         webView.loadFileURL(url, allowingReadAccessTo: url.deletingLastPathComponent())
@@ -164,15 +164,9 @@ extension ChatTranscriptWebRepresentable: NSViewRepresentable {
 
 @MainActor
 private extension ChatTranscriptWebRepresentable {
-    #if !targetEnvironment(macCatalyst)
-    static let processPool = WKProcessPool()
-    #endif
-
     static func configuration(handler: WeakScriptHandler) -> WKWebViewConfiguration {
         let config = WKWebViewConfiguration()
-        #if !targetEnvironment(macCatalyst)
-        config.processPool = processPool
-        #endif
+        config.websiteDataStore = .nonPersistent()
         let controller = WKUserContentController()
         controller.add(handler, name: Coordinator.messageName)
         config.userContentController = controller

--- a/SharedTests/ChatTranscriptRendererTests.swift
+++ b/SharedTests/ChatTranscriptRendererTests.swift
@@ -2,7 +2,7 @@
 //  ChatTranscriptRendererTests.swift
 //  FluxHaus Tests
 //
-//  Created by Copilot on 2026-05-22.
+//  Created by Testing Suite on 2026-05-22.
 //
 
 import Foundation

--- a/SharedTests/ChatTranscriptRendererTests.swift
+++ b/SharedTests/ChatTranscriptRendererTests.swift
@@ -1,0 +1,79 @@
+//
+//  ChatTranscriptRendererTests.swift
+//  FluxHaus Tests
+//
+//  Created by Copilot on 2026-05-22.
+//
+
+import Foundation
+import Testing
+@testable import FluxHaus
+
+struct ChatTranscriptRendererTests {
+
+    @Test("Transcript snapshot serializes message state")
+    func transcriptSnapshotSerializesMessageState() throws {
+        let message = ChatMessage(
+            role: .assistant,
+            content: "**Done**",
+            audioData: Data([1, 2, 3]),
+            isVoice: true,
+            isProgress: false
+        )
+        let snapshot = ChatTranscriptSnapshot(
+            conversationId: "conversation",
+            messages: [message],
+            isLoading: true,
+            playingMessageId: message.id
+        )
+
+        let json = try jsonObject(from: snapshot)
+        let messages = try #require(json["messages"] as? [[String: Any]])
+        let serialized = try #require(messages.first)
+
+        #expect(json["conversationId"] as? String == "conversation")
+        #expect(json["isLoading"] as? Bool == true)
+        #expect(serialized["id"] as? String == message.id.uuidString)
+        #expect(serialized["role"] as? String == "assistant")
+        #expect(serialized["content"] as? String == "**Done**")
+        #expect(serialized["hasAudio"] as? Bool == true)
+        #expect(serialized["isVoice"] as? Bool == true)
+        #expect(serialized["isPlaying"] as? Bool == true)
+    }
+
+    @Test("Transcript image allows only safe data URLs")
+    func transcriptImageAllowsOnlySafeDataURLs() throws {
+        let message = ChatMessage(
+            role: .user,
+            content: "images",
+            images: [
+                ChatImage(mediaType: "image/png", base64: "aGVsbG8="),
+                ChatImage(mediaType: "image/svg+xml", base64: "aGVsbG8="),
+                ChatImage(mediaType: "image/jpeg", base64: "not base64")
+            ]
+        )
+        let snapshot = ChatTranscriptSnapshot(
+            conversationId: "conversation",
+            messages: [message],
+            isLoading: false,
+            playingMessageId: nil
+        )
+
+        let json = try jsonObject(from: snapshot)
+        let messages = try #require(json["messages"] as? [[String: Any]])
+        let serialized = try #require(messages.first)
+        let images = try #require(serialized["images"] as? [[String: Any]])
+        let image = try #require(images.first)
+
+        #expect(images.count == 1)
+        #expect(image["mediaType"] as? String == "image/png")
+        #expect(image["dataURL"] as? String == "data:image/png;base64,aGVsbG8=")
+    }
+
+    private func jsonObject(from snapshot: ChatTranscriptSnapshot) throws -> [String: Any] {
+        let data = try JSONEncoder().encode(snapshot)
+        return try #require(
+            JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- render the chat transcript with a single bundled WKWebView behind a fallback flag
- add local HTML/CSS/JS renderer assets with link/audio bridging and resource restrictions
- bump all active target marketing versions to 1.8.10
- add shared tests for transcript serialization and safe image data URLs

## Validation
- swiftlint --strict --config .swiftlint.yml
- node --check Shared/ChatWebRenderer/ChatTranscriptRenderer.js
- xcodebuild -project FluxHaus.xcodeproj -scheme "FluxHaus (iOS)" -configuration Debug build CODE_SIGNING_ALLOWED=NO
- xcodebuild -project FluxHaus.xcodeproj -scheme "VisionOS" -configuration Debug build CODE_SIGNING_ALLOWED=NO
- xcodebuild -project FluxHaus.xcodeproj -scheme "FluxHaus (macOS)" -configuration Debug build CODE_SIGNING_ALLOWED=NO
- xcodebuild test -project FluxHaus.xcodeproj -scheme "VisionOS" -destination 'platform=visionOS Simulator,name=Apple Vision Pro' CODE_SIGNING_ALLOWED=NO