### PR TITLE
Fix chat webview font size and auto-scroll behavior

### DIFF
--- a/Shared/ChatWebRenderer/ChatTranscriptRenderer.css
+++ b/Shared/ChatWebRenderer/ChatTranscriptRenderer.css
@@ -14,8 +14,8 @@
   --border: rgba(76, 79, 105, 0.18);
   --blockquote-border: rgba(254, 100, 11, 0.55);
   --radius: 18px;
-  --font-size: calc(18px * var(--scale));
-  --small-size: calc(14px * var(--scale));
+  --font-size: calc(15px * var(--scale));
+  --small-size: calc(12px * var(--scale));
 }
 
 html,

--- a/Shared/ChatWebRenderer/ChatTranscriptRenderer.js
+++ b/Shared/ChatWebRenderer/ChatTranscriptRenderer.js
@@ -6,6 +6,15 @@
     : null;
   const transcript = document.getElementById("transcript");
   let lastMessageId = null;
+  let userScrolledUp = false;
+
+  function isNearBottom() {
+    return window.innerHeight + window.scrollY >= document.documentElement.scrollHeight - 80;
+  }
+
+  window.addEventListener("scroll", () => {
+    userScrolledUp = !isNearBottom();
+  }, { passive: true });
 
   function post(message) {
     if (bridge) bridge.postMessage(message);
@@ -233,10 +242,6 @@
     </div>`;
   }
 
-  function shouldStickToBottom() {
-    return window.innerHeight + window.scrollY >= document.documentElement.scrollHeight - 80;
-  }
-
   function scrollToBottom() {
     window.requestAnimationFrame(() => window.scrollTo(0, document.documentElement.scrollHeight));
   }
@@ -248,11 +253,15 @@
     },
     render(snapshot) {
       const nextLast = snapshot.messages[snapshot.messages.length - 1]?.id || null;
-      const stick = shouldStickToBottom() || lastMessageId !== nextLast;
+      const hasNewMessage = lastMessageId !== nextLast;
+      const stick = !userScrolledUp || hasNewMessage;
       transcript.innerHTML = snapshot.messages.map(renderMessage).join("") +
         (snapshot.isLoading ? typingIndicator() : "");
       lastMessageId = nextLast;
-      if (stick) scrollToBottom();
+      if (stick) {
+        userScrolledUp = false;
+        scrollToBottom();
+      }
     }
   };
 


### PR DESCRIPTION
## Changes

- **Font size**: Reduced base font from 18px to 15px to better match native iOS body text sizing. Small font reduced from 14px to 12px.
- **Auto-scroll**: Replaced the pre-render scroll-position check with a user-intent tracking approach. The transcript now stays pinned to the bottom as new messages stream in, and only disengages when the user explicitly scrolls up. New messages always re-engage auto-scroll.