### PR TITLE
feat: add App Intents for Siri, Apple Intelligence, Spotlight & Shortcuts

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -33,11 +33,11 @@ jobs:
         include:
           - name: iOS
             scheme: 'FluxHaus (iOS)'
-            destination: 'generic/platform=iOS'
+            destination: 'generic/platform=iOS Simulator'
             extra: ''
           - name: visionOS
             scheme: 'VisionOS'
-            destination: 'generic/platform=visionOS'
+            destination: 'generic/platform=visionOS Simulator'
             extra: ''
           - name: macOS
             scheme: 'FluxHaus (macOS)'

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,78 @@
+name: Build & Test
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/build-test.yml'
+      - '**/*.swift'
+      - '**/*.plist'
+      - '**/*.entitlements'
+      - 'FluxHaus.xcodeproj/**'
+      - 'Packages/**'
+  pull_request:
+    paths:
+      - '.github/workflows/build-test.yml'
+      - '**/*.swift'
+      - '**/*.plist'
+      - '**/*.entitlements'
+      - 'FluxHaus.xcodeproj/**'
+      - 'Packages/**'
+
+concurrency:
+  group: build-test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build ${{ matrix.name }}
+    runs-on: macos-26
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: iOS
+            scheme: 'FluxHaus (iOS)'
+            destination: 'generic/platform=iOS'
+            extra: ''
+          - name: visionOS
+            scheme: 'VisionOS'
+            destination: 'generic/platform=visionOS'
+            extra: ''
+          - name: macOS
+            scheme: 'FluxHaus (macOS)'
+            destination: 'generic/platform=macOS'
+            extra: 'CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Show Xcode version
+        run: xcodebuild -version
+      - name: Ensure xcbeautify
+        run: which xcbeautify || brew install xcbeautify
+      - name: Build ${{ matrix.name }}
+        run: |
+          set -o pipefail
+          xcodebuild \
+            -project FluxHaus.xcodeproj \
+            -scheme "${{ matrix.scheme }}" \
+            -destination '${{ matrix.destination }}' \
+            ${{ matrix.extra }} \
+            build | xcbeautify
+
+  test:
+    name: Test (VisionOS unit tests)
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@v4
+      - name: Show Xcode version
+        run: xcodebuild -version
+      - name: Ensure xcbeautify
+        run: which xcbeautify || brew install xcbeautify
+      - name: Run unit tests
+        run: |
+          set -o pipefail
+          xcodebuild \
+            -project FluxHaus.xcodeproj \
+            -scheme "VisionOS" \
+            -destination 'platform=visionOS Simulator,name=Apple Vision Pro' \
+            test | xcbeautify

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -23,6 +23,9 @@ concurrency:
   group: build-test-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build ${{ matrix.name }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ name: Lint
 on:
   pull_request:
     paths:
-      - '.github/workflows/swiftlint.yml'
+      - '.github/workflows/lint.yml'
       - '.swiftlint.yml'
       - '**/*.swift'
 

--- a/FluxHaus.xcodeproj/project.pbxproj
+++ b/FluxHaus.xcodeproj/project.pbxproj
@@ -1531,7 +1531,7 @@
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.11;
+				MARKETING_VERSION = 1.8.12;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.davidjensenius.FluxHaus.Tests-macOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
@@ -1597,7 +1597,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.11;
+				MARKETING_VERSION = 1.8.12;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -1658,7 +1658,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.11;
+				MARKETING_VERSION = 1.8.12;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -1686,7 +1686,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.11;
+				MARKETING_VERSION = 1.8.12;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus;
 				PRODUCT_NAME = FluxHaus;
 				SDKROOT = iphoneos;
@@ -1719,7 +1719,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.11;
+				MARKETING_VERSION = 1.8.12;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus;
 				PRODUCT_NAME = FluxHaus;
 				SDKROOT = iphoneos;
@@ -1748,7 +1748,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.11;
+				MARKETING_VERSION = 1.8.12;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.davidjensenius.Tests-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1775,7 +1775,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.11;
+				MARKETING_VERSION = 1.8.12;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.davidjensenius.Tests-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1814,7 +1814,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.8.11;
+				MARKETING_VERSION = 1.8.12;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus.FluxWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1853,7 +1853,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.8.11;
+				MARKETING_VERSION = 1.8.12;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus.FluxWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1890,7 +1890,7 @@
 					"@executable_path/Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.8.11;
+				MARKETING_VERSION = 1.8.12;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus;
 				PRODUCT_MODULE_NAME = FluxHaus;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1928,7 +1928,7 @@
 					"@executable_path/Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.8.11;
+				MARKETING_VERSION = 1.8.12;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus;
 				PRODUCT_MODULE_NAME = FluxHaus;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1954,7 +1954,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.8.11;
+				MARKETING_VERSION = 1.8.12;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jensenius.fluxhaus.VisionOSTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = xros;
@@ -1980,7 +1980,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.8.11;
+				MARKETING_VERSION = 1.8.12;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jensenius.fluxhaus.VisionOSTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = xros;
@@ -2027,7 +2027,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.11;
+				MARKETING_VERSION = 1.8.12;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus;
 				PRODUCT_NAME = FluxHaus;
 				SDKROOT = macosx;
@@ -2067,7 +2067,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.11;
+				MARKETING_VERSION = 1.8.12;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus;
 				PRODUCT_NAME = FluxHaus;
 				SDKROOT = macosx;
@@ -2083,7 +2083,7 @@
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.11;
+				MARKETING_VERSION = 1.8.12;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.davidjensenius.FluxHaus.Tests-macOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;

--- a/FluxHaus.xcodeproj/project.pbxproj
+++ b/FluxHaus.xcodeproj/project.pbxproj
@@ -11,7 +11,11 @@
 		01CDBF3D1C40C982D9108D0A /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2A45F8EEDC9709FC705CE7 /* LoginView.swift */; };
 		0346F947F8AB67D4BD3DB774 /* WeatherView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636B9B39258E57D400DE97BD /* WeatherView.swift */; };
 		0519DE362C5E9763003F3796 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1287B4482C5E9763003F3796 /* Theme.swift */; };
+		057460FC18168E1CE9B3C520 /* RobotIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = E38B4A64D5666D588E647CA0 /* RobotIntents.swift */; };
+		0AC5EE3121562133680D3C3C /* RobotIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = E38B4A64D5666D588E647CA0 /* RobotIntents.swift */; };
 		0B1E0128C093516D2338D7B8 /* Weather.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636B9B44258E5C3600DE97BD /* Weather.swift */; };
+		0CC21D2502790A21385B0E63 /* FluxIntentActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9D32097FA44F78B3A97A743 /* FluxIntentActions.swift */; };
+		0CEF749139216C90BD12F288 /* AppIntentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BFC7684CFC56D913ACB314A /* AppIntentsTests.swift */; };
 		0EBB163D8B0C468A99FB9F63 /* RobotsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023E1C2F41844A628251CE04 /* RobotsListView.swift */; };
 		0FDA7AE0AE986D66811CD243 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35E37BE77DA97D1A7B4F3394 /* ContentView.swift */; };
 		1055B6B9BB3C5FAB335B47EE /* AppliancesViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 632CBC7D25870CBB003E4999 /* AppliancesViewExtensions.swift */; };
@@ -28,9 +32,17 @@
 		233E302E4A3E42AEA96D94E2 /* Scooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF67D2F97BC4B6C8737FCC9 /* Scooter.swift */; };
 		256B98E625030109C7B0072B /* FluxHausConsts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 632CBC7625870B74003E4988 /* FluxHausConsts.swift */; };
 		25E035A77577F0A7C6C1FAA6 /* WeatherKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0DAA8E4FA345D42B212CB7AE /* WeatherKit.framework */; };
+		260466D11808C378D027C7C8 /* CarIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45C4E146327FD1D9CBFE6A47 /* CarIntents.swift */; };
+		2669250C23932E3E26B5387B /* SceneIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = A99B53B9664ECD2C6F981E9D /* SceneIntents.swift */; };
+		2A9B4E8BE8B7737DD9667E18 /* FluxIntentActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9D32097FA44F78B3A97A743 /* FluxIntentActions.swift */; };
+		2B436CB5F8250F69DF304824 /* StatusIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B56D970AFBA3A10835EE7D9 /* StatusIntents.swift */; };
 		2C8F07D87EFD2DA8DEFBB58F /* Chat.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001000000000000000002 /* Chat.swift */; };
+		2D20AA22F4ED2E10EAEFC33E /* SceneIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = A99B53B9664ECD2C6F981E9D /* SceneIntents.swift */; };
+		2E1D40C98BE0FF4DC9908011 /* CarIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45C4E146327FD1D9CBFE6A47 /* CarIntents.swift */; };
+		2F0F61B01E0417876339D892 /* AskFluxHausIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 782942CD000CCCFFE0D7C43F /* AskFluxHausIntent.swift */; };
 		31FCD81922AE005906F0AC46 /* WeatherHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAAEBC8C9F79B50F67076AB6 /* WeatherHelpers.swift */; };
 		323C8C60BEA480D9040C3B37 /* RobotDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 637CE4C42BE71FC000258158 /* RobotDetailView.swift */; };
+		356CABB63DDB3E4A42EBEBEB /* FluxHausShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D432F22FDA43AC78A33FFF /* FluxHausShortcuts.swift */; };
 		36CDAE36186F337CA02795D9 /* HomeConnect.swift in Sources */ = {isa = PBXBuildFile; fileRef = 632CBC8F2587B4AD003E4988 /* HomeConnect.swift */; };
 		36D5A7173B8D7FC007D2B1C0 /* SceneService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B21E737133023F1FB8033FE1 /* SceneService.swift */; };
 		37D0A0010000000000000001 /* SuggestionChips.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37D0A0000000000000000001 /* SuggestionChips.swift */; };
@@ -42,10 +54,14 @@
 		3CFA1F5604BA445D83EE6D88 /* ScooterDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8CB990FC6404C8682E3BE62 /* ScooterDetailView.swift */; };
 		3F181EC009E59832882455EA /* WeatherHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAAEBC8C9F79B50F67076AB6 /* WeatherHelpers.swift */; };
 		42E9D45E3DEE4ED4BF3EBB9C /* ScooterDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8CB990FC6404C8682E3BE62 /* ScooterDetailView.swift */; };
+		44AB10F051A0C91C563B0EE4 /* FluxIntentActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9D32097FA44F78B3A97A743 /* FluxIntentActions.swift */; };
 		47DAD3A56DB24CE1A601DE56 /* DateTimeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 632CBC25258682C8003E4988 /* DateTimeView.swift */; };
+		49CC496DED762D35041AA043 /* CarIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45C4E146327FD1D9CBFE6A47 /* CarIntents.swift */; };
 		4C4BF431831E40DDB81B5B12 /* Scooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF67D2F97BC4B6C8737FCC9 /* Scooter.swift */; };
 		4C7C9D7BE074D65A480045A1 /* Miele.swift in Sources */ = {isa = PBXBuildFile; fileRef = 632CBC6F2586C79E003E4988 /* Miele.swift */; };
+		4E7F93DA12B2963DD1150BD8 /* FluxIntentActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9D32097FA44F78B3A97A743 /* FluxIntentActions.swift */; };
 		4EE7C07CB284872F0B2165AB /* CarHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 633F09472BBB8F8F0052C088 /* CarHelper.swift */; };
+		4FD86E14AA62A32A6FF600A8 /* CarIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45C4E146327FD1D9CBFE6A47 /* CarIntents.swift */; };
 		55FD5BBD882FC925D75E3214 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1287B4482C5E9763003F3796 /* Theme.swift */; };
 		58489E7EBF8C80A6A3DFF2AD /* Battery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636A05982B9E6EE800D42C0D /* Battery.swift */; };
 		5A5D2CC899AC78FE86363152 /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 726CDAE4D264490999414676 /* AuthManager.swift */; };
@@ -55,6 +71,7 @@
 		5D05B5523942BB577B0175D4 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2A45F8EEDC9709FC705CE7 /* LoginView.swift */; };
 		5D4730DE346F4F3096732C83 /* RobotsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023E1C2F41844A628251CE04 /* RobotsListView.swift */; };
 		5E7EE46FF4B2D86974A97228 /* AppliancesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 632CBC7D25870CBB003E4988 /* AppliancesView.swift */; };
+		5E7F9732F0E2D22130D6E339 /* StatusIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B56D970AFBA3A10835EE7D9 /* StatusIntents.swift */; };
 		63282DC52B992B08009140F2 /* DateTimeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 632CBC25258682C8003E4988 /* DateTimeView.swift */; };
 		632CBC40258682C9003E4988 /* Tests_iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 632CBC3F258682C9003E4988 /* Tests_iOS.swift */; };
 		632CBC4D258682C9003E4988 /* FluxHausApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 632CBC24258682C8003E4988 /* FluxHausApp.swift */; };
@@ -70,7 +87,6 @@
 		633F094A2BBB8F8F0052C088 /* CarHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 633F09472BBB8F8F0052C088 /* CarHelper.swift */; };
 		634056CD2E47FDBA001F8278 /* Tests_iOS_SwiftTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 634056CC2E47FDBA001F8278 /* Tests_iOS_SwiftTesting.swift */; };
 		634056DC2E47FFC2001F8278 /* WhereWeAreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 634056D32E47FFC2001F8278 /* WhereWeAreTests.swift */; };
-		CTR0005000000000000000001 /* ChatTranscriptRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CTR0005000000000000000002 /* ChatTranscriptRendererTests.swift */; };
 		634056DD2E47FFC2001F8278 /* HomeConnectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 634056CF2E47FFC2001F8278 /* HomeConnectTests.swift */; };
 		634056DE2E47FFC2001F8278 /* BatteryAndWeatherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 634056CE2E47FFC2001F8278 /* BatteryAndWeatherTests.swift */; };
 		634056DF2E47FFC2001F8278 /* SharedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 634056D22E47FFC2001F8278 /* SharedTests.swift */; };
@@ -162,19 +178,27 @@
 		63DBD75C2B954486006603D1 /* AppliancesViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 632CBC7D25870CBB003E4999 /* AppliancesViewExtensions.swift */; };
 		63EB92652BE7E63C00B73102 /* ApplianceDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63EB92642BE7E63C00B73102 /* ApplianceDetailView.swift */; };
 		63EB92672BE7E63C00B73102 /* ApplianceDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63EB92642BE7E63C00B73102 /* ApplianceDetailView.swift */; };
+		6459694F94969E90B6F5CD9F /* RobotIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = E38B4A64D5666D588E647CA0 /* RobotIntents.swift */; };
+		65AC26A6D238F5635F082B02 /* RobotIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = E38B4A64D5666D588E647CA0 /* RobotIntents.swift */; };
 		66106D4DFC5F30C42C88F574 /* MenuBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76553EE6B9F944EC9FC27BB7 /* MenuBarView.swift */; };
+		6761CEA937D36001BDB9337C /* SceneIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = A99B53B9664ECD2C6F981E9D /* SceneIntents.swift */; };
+		6C718CFE95C3BC769046E180 /* CarIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45C4E146327FD1D9CBFE6A47 /* CarIntents.swift */; };
 		6D3A6DF0ADB0547372080998 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 632CBC26258682C9003E4988 /* Assets.xcassets */; };
 		6FCFCDBD5CD529EC139A4A95 /* ApplianceViewHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63610D2D2BB883DA0048B9FF /* ApplianceViewHelpers.swift */; };
+		76BEC2C027094075424FAC66 /* SceneIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = A99B53B9664ECD2C6F981E9D /* SceneIntents.swift */; };
 		76FDEBDB0F31F8539E4A8B91 /* SceneService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B21E737133023F1FB8033FE1 /* SceneService.swift */; };
 		773F6A161767F7B9301A70C8 /* LoginStucts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63A159272C5E9763003F3796 /* LoginStucts.swift */; };
 		77CDDA9FA1A142A79B3AEB86 /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 726CDAE4D264490999414676 /* AuthManager.swift */; };
 		77FD37A48518D9CC2AF19BFA /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 726CDAE4D264490999414676 /* AuthManager.swift */; };
 		792A9034DF4408D90BF13274 /* LoginStucts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63A159272C5E9763003F3796 /* LoginStucts.swift */; };
+		7C912107F52EFE69ABBD2EC9 /* FluxHausShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D432F22FDA43AC78A33FFF /* FluxHausShortcuts.swift */; };
 		84C5DCC07BF2CE1E4D72F885 /* WhereWeAre.swift in Sources */ = {isa = PBXBuildFile; fileRef = 635BD66F2B9DFAE1009CEEA9 /* WhereWeAre.swift */; };
 		863DE0E082704AD840741003 /* ApplianceDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63EB92642BE7E63C00B73102 /* ApplianceDetailView.swift */; };
+		863F05984934657C4DFF4C77 /* StatusIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B56D970AFBA3A10835EE7D9 /* StatusIntents.swift */; };
 		8716D5FE3271F7DBCEF8D744 /* ChatService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001000000000000000001 /* ChatService.swift */; };
 		88A694EA13C5590830184818 /* CarDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63610D322BB8864F0048B9FF /* CarDetailView.swift */; };
 		8D80E6BB0FEBF2D6F21674BD /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AC70F639352E9D9252F77D43 /* Cocoa.framework */; };
+		914CBFB490B76988B7373B05 /* AskFluxHausIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 782942CD000CCCFFE0D7C43F /* AskFluxHausIntent.swift */; };
 		92895C4DCFEB63889AE653C5 /* Car.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63610D282BB86F230048B9FF /* Car.swift */; };
 		92BB68B7C6E3ED9215465CAB /* DateTimeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 632CBC25258682C8003E4988 /* DateTimeView.swift */; };
 		92D95E3AA3B5D0695A884C19 /* CarPlaySceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C755D2CAD40D63EDE9D51C7 /* CarPlaySceneDelegate.swift */; };
@@ -182,6 +206,7 @@
 		99ACB989B61624E98A2D48A8 /* Tests_macOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 632CBC4A258682C9003E4988 /* Tests_macOS.swift */; };
 		9D14B888828F5291C3A1B2D5 /* Miele.swift in Sources */ = {isa = PBXBuildFile; fileRef = 632CBC6F2586C79E003E4988 /* Miele.swift */; };
 		9F0AB88C6586E3EEFCE46F8B /* SceneService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B21E737133023F1FB8033FE1 /* SceneService.swift */; };
+		A08741F491FBACE4244D359F /* AskFluxHausIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 782942CD000CCCFFE0D7C43F /* AskFluxHausIntent.swift */; };
 		A0ED8B507C7C96F517EF4525 /* SceneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6709013ABF8AA633E63B128 /* SceneView.swift */; };
 		A1319CBC6B75067B33D60A3B /* BackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636B9B4F258E912A00DE97BD /* BackgroundView.swift */; };
 		A7EB26F31FDF9BA1C1907FEE /* Robots.swift in Sources */ = {isa = PBXBuildFile; fileRef = 635BD66A2B9DF8A6009CEEA9 /* Robots.swift */; };
@@ -205,11 +230,13 @@
 		B87954247FC0FC7450CF2A8D /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1287B4482C5E9763003F3796 /* Theme.swift */; };
 		B894A7B443EB0DAA9E9BC45B /* Api.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63BCF7542C63FABB001D4375 /* Api.swift */; };
 		BA938AC82C5E9763003F3796 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1287B4482C5E9763003F3796 /* Theme.swift */; };
+		BAC011F1870F66549C4C6D4E /* FluxHausShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D432F22FDA43AC78A33FFF /* FluxHausShortcuts.swift */; };
 		BD30D0FA8BD289D1AB96975A /* SceneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6709013ABF8AA633E63B128 /* SceneView.swift */; };
 		BE52C047E38648D2BBCF9F89 /* Scooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF67D2F97BC4B6C8737FCC9 /* Scooter.swift */; };
 		BEA67E939CA04EFAA36CEACF /* Scooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF67D2F97BC4B6C8737FCC9 /* Scooter.swift */; };
 		C26CB6CAACD7386DAA031965 /* Robots.swift in Sources */ = {isa = PBXBuildFile; fileRef = 635BD66A2B9DF8A6009CEEA9 /* Robots.swift */; };
 		C34D4AD44612F44CC7E6D464 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35E37BE77DA97D1A7B4F3394 /* ContentView.swift */; };
+		C407064D75A040943618FCF3 /* AskFluxHausIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 782942CD000CCCFFE0D7C43F /* AskFluxHausIntent.swift */; };
 		C4441A6919614E6E833113C0 /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 726CDAE4D264490999414676 /* AuthManager.swift */; };
 		C5CEC5CCBE620D65D2B1C9BC /* Login.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6399EA302B9D3671000C8CA4 /* Login.swift */; };
 		C623C52748905A66CF3956EB /* MenuBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76553EE6B9F944EC9FC27BB7 /* MenuBarView.swift */; };
@@ -217,14 +244,28 @@
 		CB0002000000000000000002 /* ChatBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0001000000000000000001 /* ChatBubble.swift */; };
 		CB0002000000000000000003 /* ChatBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0001000000000000000001 /* ChatBubble.swift */; };
 		CB0002000000000000000004 /* ChatBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0001000000000000000001 /* ChatBubble.swift */; };
-		CWV0002000000000000000001 /* ConversationWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CWV0001000000000000000001 /* ConversationWebView.swift */; };
-		CWV0002000000000000000002 /* ConversationWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CWV0001000000000000000001 /* ConversationWebView.swift */; };
-		CWV0002000000000000000003 /* ConversationWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CWV0001000000000000000001 /* ConversationWebView.swift */; };
-		CWV0002000000000000000004 /* ConversationWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CWV0001000000000000000001 /* ConversationWebView.swift */; };
 		CSV0001000000000000000001 /* ConversationScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CSV0000000000000000000001 /* ConversationScrollView.swift */; };
 		CSV0001000000000000000002 /* ConversationScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CSV0000000000000000000001 /* ConversationScrollView.swift */; };
 		CSV0001000000000000000003 /* ConversationScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CSV0000000000000000000001 /* ConversationScrollView.swift */; };
 		CSV0001000000000000000004 /* ConversationScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CSV0000000000000000000001 /* ConversationScrollView.swift */; };
+		CTR0002000000000000000001 /* ChatTranscriptRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CTR0001000000000000000001 /* ChatTranscriptRenderer.swift */; };
+		CTR0002000000000000000002 /* ChatTranscriptRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CTR0001000000000000000001 /* ChatTranscriptRenderer.swift */; };
+		CTR0002000000000000000003 /* ChatTranscriptRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CTR0001000000000000000001 /* ChatTranscriptRenderer.swift */; };
+		CTR0002000000000000000004 /* ChatTranscriptRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CTR0001000000000000000001 /* ChatTranscriptRenderer.swift */; };
+		CTR0003000000000000000001 /* ChatTranscriptRenderer.html in Resources */ = {isa = PBXBuildFile; fileRef = CTR0001000000000000000002 /* ChatTranscriptRenderer.html */; };
+		CTR0003000000000000000002 /* ChatTranscriptRenderer.html in Resources */ = {isa = PBXBuildFile; fileRef = CTR0001000000000000000002 /* ChatTranscriptRenderer.html */; };
+		CTR0003000000000000000003 /* ChatTranscriptRenderer.html in Resources */ = {isa = PBXBuildFile; fileRef = CTR0001000000000000000002 /* ChatTranscriptRenderer.html */; };
+		CTR0003000000000000000004 /* ChatTranscriptRenderer.css in Resources */ = {isa = PBXBuildFile; fileRef = CTR0001000000000000000003 /* ChatTranscriptRenderer.css */; };
+		CTR0003000000000000000005 /* ChatTranscriptRenderer.css in Resources */ = {isa = PBXBuildFile; fileRef = CTR0001000000000000000003 /* ChatTranscriptRenderer.css */; };
+		CTR0003000000000000000006 /* ChatTranscriptRenderer.css in Resources */ = {isa = PBXBuildFile; fileRef = CTR0001000000000000000003 /* ChatTranscriptRenderer.css */; };
+		CTR0003000000000000000007 /* ChatTranscriptRenderer.js in Resources */ = {isa = PBXBuildFile; fileRef = CTR0001000000000000000004 /* ChatTranscriptRenderer.js */; };
+		CTR0003000000000000000008 /* ChatTranscriptRenderer.js in Resources */ = {isa = PBXBuildFile; fileRef = CTR0001000000000000000004 /* ChatTranscriptRenderer.js */; };
+		CTR0003000000000000000009 /* ChatTranscriptRenderer.js in Resources */ = {isa = PBXBuildFile; fileRef = CTR0001000000000000000004 /* ChatTranscriptRenderer.js */; };
+		CTR0005000000000000000001 /* ChatTranscriptRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CTR0005000000000000000002 /* ChatTranscriptRendererTests.swift */; };
+		CWV0002000000000000000001 /* ConversationWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CWV0001000000000000000001 /* ConversationWebView.swift */; };
+		CWV0002000000000000000002 /* ConversationWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CWV0001000000000000000001 /* ConversationWebView.swift */; };
+		CWV0002000000000000000003 /* ConversationWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CWV0001000000000000000001 /* ConversationWebView.swift */; };
+		CWV0002000000000000000004 /* ConversationWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CWV0001000000000000000001 /* ConversationWebView.swift */; };
 		D170D5FEA1F77CDDD5473F1B /* WeatherView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636B9B39258E57D400DE97BD /* WeatherView.swift */; };
 		D402DD36EF6240BBA92FBDBB /* FluxWidgetLiveActivityLegacy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41D5E7C6F4C54541B6F1C1E9 /* FluxWidgetLiveActivityLegacy.swift */; };
 		D4CF7F9BD9DD51C77C6AB4C9 /* ChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B9B78F7F035E29316F494F7 /* ChatView.swift */; };
@@ -242,6 +283,9 @@
 		E222079D6E3C7E5941D2D5C0 /* CarHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 633F09472BBB8F8F0052C088 /* CarHelper.swift */; };
 		E45053421DDDDCF16D51FBAD /* Api.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63BCF7542C63FABB001D4375 /* Api.swift */; };
 		E7A98893E6A36343187C94F3 /* ApplianceDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63EB92642BE7E63C00B73102 /* ApplianceDetailView.swift */; };
+		E8F51AC7B9126DD96390720E /* StatusIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B56D970AFBA3A10835EE7D9 /* StatusIntents.swift */; };
+		EA4EE864901D2B3105A7F885 /* FluxIntentActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9D32097FA44F78B3A97A743 /* FluxIntentActions.swift */; };
+		EB186FDC19BACF05F5B9FA83 /* FluxHausShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D432F22FDA43AC78A33FFF /* FluxHausShortcuts.swift */; };
 		EDBA0282938D145D6381768C /* MacApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 731A02EE588AFF8C715B9DEB /* MacApp.swift */; };
 		EE07E20294AB53EAC4703BE6 /* Car.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63610D282BB86F230048B9FF /* Car.swift */; };
 		EFE1927CBD7F01E5524E63DA /* ApplianceViewHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63610D2D2BB883DA0048B9FF /* ApplianceViewHelpers.swift */; };
@@ -249,6 +293,7 @@
 		F0C99470023B4D8053698472 /* Tests_macOS_SwiftTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77A49425BDF4F7DDFA1EE83F /* Tests_macOS_SwiftTesting.swift */; };
 		F10D9EC8F5EA4EE8B2DCD1D7 /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 726CDAE4D264490999414676 /* AuthManager.swift */; };
 		F27145294822FFB5FE80E84F /* ChatService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001000000000000000001 /* ChatService.swift */; };
+		F3C3D67FDFFEFDA41639835B /* RobotIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = E38B4A64D5666D588E647CA0 /* RobotIntents.swift */; };
 		F57287FA1413E1215F02B546 /* LiveActivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E1EE68A8DCE61464036EA06 /* LiveActivityManager.swift */; };
 		FBA9A54858486FCD8D6AD240 /* Weather.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636B9B44258E5C3600DE97BD /* Weather.swift */; };
 		FC70519504B244809D095CEC /* ScooterDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8CB990FC6404C8682E3BE62 /* ScooterDetailView.swift */; };
@@ -260,19 +305,6 @@
 		MD0002000000000000000002 /* MarkdownContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = MD0001000000000000000001 /* MarkdownContentView.swift */; };
 		MD0002000000000000000003 /* MarkdownContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = MD0001000000000000000001 /* MarkdownContentView.swift */; };
 		MD0002000000000000000004 /* MarkdownContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = MD0001000000000000000001 /* MarkdownContentView.swift */; };
-		CTR0002000000000000000001 /* ChatTranscriptRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CTR0001000000000000000001 /* ChatTranscriptRenderer.swift */; };
-		CTR0002000000000000000002 /* ChatTranscriptRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CTR0001000000000000000001 /* ChatTranscriptRenderer.swift */; };
-		CTR0002000000000000000003 /* ChatTranscriptRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CTR0001000000000000000001 /* ChatTranscriptRenderer.swift */; };
-		CTR0002000000000000000004 /* ChatTranscriptRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CTR0001000000000000000001 /* ChatTranscriptRenderer.swift */; };
-		CTR0003000000000000000001 /* ChatTranscriptRenderer.html in Resources */ = {isa = PBXBuildFile; fileRef = CTR0001000000000000000002 /* ChatTranscriptRenderer.html */; };
-		CTR0003000000000000000002 /* ChatTranscriptRenderer.html in Resources */ = {isa = PBXBuildFile; fileRef = CTR0001000000000000000002 /* ChatTranscriptRenderer.html */; };
-		CTR0003000000000000000003 /* ChatTranscriptRenderer.html in Resources */ = {isa = PBXBuildFile; fileRef = CTR0001000000000000000002 /* ChatTranscriptRenderer.html */; };
-		CTR0003000000000000000004 /* ChatTranscriptRenderer.css in Resources */ = {isa = PBXBuildFile; fileRef = CTR0001000000000000000003 /* ChatTranscriptRenderer.css */; };
-		CTR0003000000000000000005 /* ChatTranscriptRenderer.css in Resources */ = {isa = PBXBuildFile; fileRef = CTR0001000000000000000003 /* ChatTranscriptRenderer.css */; };
-		CTR0003000000000000000006 /* ChatTranscriptRenderer.css in Resources */ = {isa = PBXBuildFile; fileRef = CTR0001000000000000000003 /* ChatTranscriptRenderer.css */; };
-		CTR0003000000000000000007 /* ChatTranscriptRenderer.js in Resources */ = {isa = PBXBuildFile; fileRef = CTR0001000000000000000004 /* ChatTranscriptRenderer.js */; };
-		CTR0003000000000000000008 /* ChatTranscriptRenderer.js in Resources */ = {isa = PBXBuildFile; fileRef = CTR0001000000000000000004 /* ChatTranscriptRenderer.js */; };
-		CTR0003000000000000000009 /* ChatTranscriptRenderer.js in Resources */ = {isa = PBXBuildFile; fileRef = CTR0001000000000000000004 /* ChatTranscriptRenderer.js */; };
 		MP0002000000000000000001 /* MarkdownParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = MP0001000000000000000001 /* MarkdownParser.swift */; };
 		MP0002000000000000000002 /* MarkdownParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = MP0001000000000000000001 /* MarkdownParser.swift */; };
 		MP0002000000000000000003 /* MarkdownParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = MP0001000000000000000001 /* MarkdownParser.swift */; };
@@ -353,9 +385,12 @@
 		1287B4482C5E9763003F3796 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		1B9B78F7F035E29316F494F7 /* ChatView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ChatView.swift; sourceTree = "<group>"; };
 		1C755D2CAD40D63EDE9D51C7 /* CarPlaySceneDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CarPlaySceneDelegate.swift; sourceTree = "<group>"; };
+		2B56D970AFBA3A10835EE7D9 /* StatusIntents.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StatusIntents.swift; sourceTree = "<group>"; };
 		35E37BE77DA97D1A7B4F3394 /* ContentView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		37D0A0000000000000000001 /* SuggestionChips.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionChips.swift; sourceTree = "<group>"; };
 		41D5E7C6F4C54541B6F1C1E9 /* FluxWidgetLiveActivityLegacy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FluxWidgetLiveActivityLegacy.swift; sourceTree = "<group>"; };
+		45C4E146327FD1D9CBFE6A47 /* CarIntents.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CarIntents.swift; sourceTree = "<group>"; };
+		4BFC7684CFC56D913ACB314A /* AppIntentsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppIntentsTests.swift; sourceTree = "<group>"; };
 		54E080FFA20990ACE9D14FB1 /* FluxHaus.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FluxHaus.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		57CB3B0423E7608E287483D2 /* DashboardView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DashboardView.swift; sourceTree = "<group>"; };
 		632CBC24258682C8003E4988 /* FluxHausApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FluxHausApp.swift; sourceTree = "<group>"; };
@@ -387,7 +422,6 @@
 		634056D22E47FFC2001F8278 /* SharedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedTests.swift; sourceTree = "<group>"; };
 		634056D32E47FFC2001F8278 /* WhereWeAreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhereWeAreTests.swift; sourceTree = "<group>"; };
 		634056D42E47FFC2001F8278 /* WidgetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetTests.swift; sourceTree = "<group>"; };
-		CTR0005000000000000000002 /* ChatTranscriptRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTranscriptRendererTests.swift; sourceTree = "<group>"; };
 		635BD66A2B9DF8A6009CEEA9 /* Robots.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Robots.swift; sourceTree = "<group>"; };
 		635BD66F2B9DFAE1009CEEA9 /* WhereWeAre.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhereWeAre.swift; sourceTree = "<group>"; };
 		635BD6742B9E030E009CEEA9 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -439,9 +473,11 @@
 		731A02EE588AFF8C715B9DEB /* MacApp.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MacApp.swift; sourceTree = "<group>"; };
 		76553EE6B9F944EC9FC27BB7 /* MenuBarView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MenuBarView.swift; sourceTree = "<group>"; };
 		77A49425BDF4F7DDFA1EE83F /* Tests_macOS_SwiftTesting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_macOS_SwiftTesting.swift; sourceTree = "<group>"; };
+		782942CD000CCCFFE0D7C43F /* AskFluxHausIntent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AskFluxHausIntent.swift; sourceTree = "<group>"; };
 		8757ED2EF3E226D6B1548CAE /* SettingsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		9E1EE68A8DCE61464036EA06 /* LiveActivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityManager.swift; sourceTree = "<group>"; };
 		A014C8FED1F0DB5B5127FCB1 /* Tests macOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Tests macOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		A99B53B9664ECD2C6F981E9D /* SceneIntents.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SceneIntents.swift; sourceTree = "<group>"; };
 		AA0001000000000000000001 /* ChatService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatService.swift; sourceTree = "<group>"; };
 		AA0001000000000000000002 /* Chat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Chat.swift; sourceTree = "<group>"; };
 		AA0001000000000000000003 /* ChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatView.swift; sourceTree = "<group>"; };
@@ -452,17 +488,21 @@
 		AD54CBBAC6C6B09392534272 /* CarPlay.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CarPlay.framework; path = System/Library/Frameworks/CarPlay.framework; sourceTree = SDKROOT; };
 		B21E737133023F1FB8033FE1 /* SceneService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SceneService.swift; sourceTree = "<group>"; };
 		C2B3D4E5F6071829A3B4C5D6 /* Tests_macOS_ViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_macOS_ViewTests.swift; sourceTree = "<group>"; };
+		C4D432F22FDA43AC78A33FFF /* FluxHausShortcuts.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FluxHausShortcuts.swift; sourceTree = "<group>"; };
 		C6709013ABF8AA633E63B128 /* SceneView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SceneView.swift; sourceTree = "<group>"; };
 		C8CB990FC6404C8682E3BE62 /* ScooterDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScooterDetailView.swift; sourceTree = "<group>"; };
 		CB0001000000000000000001 /* ChatBubble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatBubble.swift; sourceTree = "<group>"; };
 		CEF67D2F97BC4B6C8737FCC9 /* Scooter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Scooter.swift; sourceTree = "<group>"; };
+		CSV0000000000000000000001 /* ConversationScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationScrollView.swift; sourceTree = "<group>"; };
 		CTR0001000000000000000001 /* ChatTranscriptRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTranscriptRenderer.swift; sourceTree = "<group>"; };
 		CTR0001000000000000000002 /* ChatTranscriptRenderer.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = ChatTranscriptRenderer.html; sourceTree = "<group>"; };
 		CTR0001000000000000000003 /* ChatTranscriptRenderer.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = ChatTranscriptRenderer.css; sourceTree = "<group>"; };
 		CTR0001000000000000000004 /* ChatTranscriptRenderer.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = ChatTranscriptRenderer.js; sourceTree = "<group>"; };
-		CSV0000000000000000000001 /* ConversationScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationScrollView.swift; sourceTree = "<group>"; };
+		CTR0005000000000000000002 /* ChatTranscriptRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTranscriptRendererTests.swift; sourceTree = "<group>"; };
 		CWV0001000000000000000001 /* ConversationWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationWebView.swift; sourceTree = "<group>"; };
 		D7F4D12AFB5260CA5BD9CE33 /* CarPlayVoiceManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CarPlayVoiceManager.swift; sourceTree = "<group>"; };
+		E38B4A64D5666D588E647CA0 /* RobotIntents.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RobotIntents.swift; sourceTree = "<group>"; };
+		F9D32097FA44F78B3A97A743 /* FluxIntentActions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FluxIntentActions.swift; sourceTree = "<group>"; };
 		FAAEBC8C9F79B50F67076AB6 /* WeatherHelpers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WeatherHelpers.swift; sourceTree = "<group>"; };
 		MD0001000000000000000001 /* MarkdownContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownContentView.swift; sourceTree = "<group>"; };
 		MP0001000000000000000001 /* MarkdownParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownParser.swift; sourceTree = "<group>"; };
@@ -539,6 +579,21 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		08BB574423DB63460BD22B44 /* Intents */ = {
+			isa = PBXGroup;
+			children = (
+				F9D32097FA44F78B3A97A743 /* FluxIntentActions.swift */,
+				E38B4A64D5666D588E647CA0 /* RobotIntents.swift */,
+				45C4E146327FD1D9CBFE6A47 /* CarIntents.swift */,
+				A99B53B9664ECD2C6F981E9D /* SceneIntents.swift */,
+				2B56D970AFBA3A10835EE7D9 /* StatusIntents.swift */,
+				782942CD000CCCFFE0D7C43F /* AskFluxHausIntent.swift */,
+				C4D432F22FDA43AC78A33FFF /* FluxHausShortcuts.swift */,
+			);
+			name = Intents;
+			path = Intents;
+			sourceTree = "<group>";
+		};
 		632CBC1E258682C8003E4988 = {
 			isa = PBXGroup;
 			children = (
@@ -616,18 +671,9 @@
 				MD0001000000000000000001 /* MarkdownContentView.swift */,
 				MP0001000000000000000001 /* MarkdownParser.swift */,
 				NS0001000000000000000001 /* NotificationSettingsView.swift */,
+				08BB574423DB63460BD22B44 /* Intents */,
 			);
 			path = Shared;
-			sourceTree = "<group>";
-		};
-		CTR0004000000000000000001 /* ChatWebRenderer */ = {
-			isa = PBXGroup;
-			children = (
-				CTR0001000000000000000002 /* ChatTranscriptRenderer.html */,
-				CTR0001000000000000000003 /* ChatTranscriptRenderer.css */,
-				CTR0001000000000000000004 /* ChatTranscriptRenderer.js */,
-			);
-			path = ChatWebRenderer;
 			sourceTree = "<group>";
 		};
 		632CBC2C258682C9003E4988 /* Products */ = {
@@ -726,6 +772,7 @@
 				634056D22E47FFC2001F8278 /* SharedTests.swift */,
 				634056D32E47FFC2001F8278 /* WhereWeAreTests.swift */,
 				634056D42E47FFC2001F8278 /* WidgetTests.swift */,
+				4BFC7684CFC56D913ACB314A /* AppIntentsTests.swift */,
 			);
 			path = SharedTests;
 			sourceTree = "<group>";
@@ -790,6 +837,16 @@
 				D7F4D12AFB5260CA5BD9CE33 /* CarPlayVoiceManager.swift */,
 			);
 			path = CarPlay;
+			sourceTree = "<group>";
+		};
+		CTR0004000000000000000001 /* ChatWebRenderer */ = {
+			isa = PBXGroup;
+			children = (
+				CTR0001000000000000000002 /* ChatTranscriptRenderer.html */,
+				CTR0001000000000000000003 /* ChatTranscriptRenderer.css */,
+				CTR0001000000000000000004 /* ChatTranscriptRenderer.js */,
+			);
+			path = ChatWebRenderer;
 			sourceTree = "<group>";
 		};
 		D064384394F50320A7808D6A /* OS X */ = {
@@ -1154,6 +1211,13 @@
 				RO0001000000000000000001 /* RadarOverlayRenderer.swift in Sources */,
 				RM0001000000000000000003 /* RadarMapViews.swift in Sources */,
 				WF0001000000000000000001 /* WeatherForecastView.swift in Sources */,
+				44AB10F051A0C91C563B0EE4 /* FluxIntentActions.swift in Sources */,
+				057460FC18168E1CE9B3C520 /* RobotIntents.swift in Sources */,
+				260466D11808C378D027C7C8 /* CarIntents.swift in Sources */,
+				2669250C23932E3E26B5387B /* SceneIntents.swift in Sources */,
+				5E7F9732F0E2D22130D6E339 /* StatusIntents.swift in Sources */,
+				A08741F491FBACE4244D359F /* AskFluxHausIntent.swift in Sources */,
+				BAC011F1870F66549C4C6D4E /* FluxHausShortcuts.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1221,6 +1285,13 @@
 				F57287FA1413E1215F02B546 /* LiveActivityManager.swift in Sources */,
 				92D95E3AA3B5D0695A884C19 /* CarPlaySceneDelegate.swift in Sources */,
 				16E5F0715B8C44C3462F4FA5 /* CarPlayVoiceManager.swift in Sources */,
+				EA4EE864901D2B3105A7F885 /* FluxIntentActions.swift in Sources */,
+				6459694F94969E90B6F5CD9F /* RobotIntents.swift in Sources */,
+				6C718CFE95C3BC769046E180 /* CarIntents.swift in Sources */,
+				6761CEA937D36001BDB9337C /* SceneIntents.swift in Sources */,
+				863F05984934657C4DFF4C77 /* StatusIntents.swift in Sources */,
+				2F0F61B01E0417876339D892 /* AskFluxHausIntent.swift in Sources */,
+				7C912107F52EFE69ABBD2EC9 /* FluxHausShortcuts.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1264,6 +1335,9 @@
 				637BC6302C5BDA8000E7884E /* FluxWidgetLiveActivity.swift in Sources */,
 				DA526145341C4A909E252425 /* FluxWidgetWatchViews.swift in Sources */,
 				D402DD36EF6240BBA92FBDBB /* FluxWidgetLiveActivityLegacy.swift in Sources */,
+				0CC21D2502790A21385B0E63 /* FluxIntentActions.swift in Sources */,
+				F3C3D67FDFFEFDA41639835B /* RobotIntents.swift in Sources */,
+				4FD86E14AA62A32A6FF600A8 /* CarIntents.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1326,6 +1400,13 @@
 				CB0002000000000000000003 /* ChatBubble.swift in Sources */,
 				MD0002000000000000000003 /* MarkdownContentView.swift in Sources */,
 				MP0002000000000000000003 /* MarkdownParser.swift in Sources */,
+				4E7F93DA12B2963DD1150BD8 /* FluxIntentActions.swift in Sources */,
+				0AC5EE3121562133680D3C3C /* RobotIntents.swift in Sources */,
+				2E1D40C98BE0FF4DC9908011 /* CarIntents.swift in Sources */,
+				2D20AA22F4ED2E10EAEFC33E /* SceneIntents.swift in Sources */,
+				E8F51AC7B9126DD96390720E /* StatusIntents.swift in Sources */,
+				C407064D75A040943618FCF3 /* AskFluxHausIntent.swift in Sources */,
+				356CABB63DDB3E4A42EBEBEB /* FluxHausShortcuts.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1341,6 +1422,7 @@
 				634056E02E47FFC2001F8278 /* IntegrationTests.swift in Sources */,
 				634056E12E47FFC2001F8278 /* QueryFluxTests.swift in Sources */,
 				634056E32E47FFC2001F8278 /* WhereWeAreTests.swift in Sources */,
+				0CEF749139216C90BD12F288 /* AppIntentsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1410,6 +1492,13 @@
 				RO0001000000000000000002 /* RadarOverlayRenderer.swift in Sources */,
 				RM0001000000000000000004 /* RadarMapViews.swift in Sources */,
 				WF0001000000000000000002 /* WeatherForecastView.swift in Sources */,
+				2A9B4E8BE8B7737DD9667E18 /* FluxIntentActions.swift in Sources */,
+				65AC26A6D238F5635F082B02 /* RobotIntents.swift in Sources */,
+				49CC496DED762D35041AA043 /* CarIntents.swift in Sources */,
+				76BEC2C027094075424FAC66 /* SceneIntents.swift in Sources */,
+				2B436CB5F8250F69DF304824 /* StatusIntents.swift in Sources */,
+				914CBFB490B76988B7373B05 /* AskFluxHausIntent.swift in Sources */,
+				EB186FDC19BACF05F5B9FA83 /* FluxHausShortcuts.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/README.md
+++ b/README.md
@@ -22,3 +22,31 @@ make test-visionos
 ```bash
 make test
 ```
+
+## Siri, Shortcuts & Apple Intelligence
+
+FluxHaus exposes its controls and AI assistant to the system through [App Intents](https://developer.apple.com/documentation/appintents).
+These ship in the iOS, visionOS, and macOS apps and are available in Siri, Spotlight, the
+Shortcuts app, and Apple Intelligence.
+
+Intent definitions live in `Shared/Intents/`:
+
+- **Robots** — start, stop, and deep clean (BroomBot & MopBot)
+- **Car** — lock, unlock, start/stop climate (defrost, heated features, temperature), and resync
+- **Scenes** — activate a HomeKit scene (the scene list is provided dynamically)
+- **Status** — car, robot, dishwasher, and scooter status queries
+- **Ask FluxHaus** — a free-text question routed to the FluxHaus AI assistant
+
+`FluxHausShortcuts` (an `AppShortcutsProvider`) registers Siri phrases such as
+“Lock my car with FluxHaus” and “Ask FluxHaus”. The system caps an app at **10** phrased
+App Shortcuts, so the remaining intents are still available as actions in the Shortcuts app.
+
+Intents reuse the shared `AuthManager` session and require the user to be signed in.
+
+### Adding a new intent
+
+1. Add the intent (and any `AppEnum`/`AppEntity`) to `Shared/Intents/`.
+2. Use `static let` for `title`/`description` (Swift 6 strict concurrency).
+3. Optionally register a phrase in `FluxHausShortcuts` (keep total ≤ 10).
+4. Add the file to the `FluxHaus (iOS)`, `VisionOS`, and `FluxHaus (macOS)` targets.
+

--- a/Shared/Car.swift
+++ b/Shared/Car.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import AppIntents
 import os
 
 private let logger = Logger(subsystem: "io.fluxhaus.FluxHaus", category: "Car")
@@ -132,9 +133,43 @@ private let logger = Logger(subsystem: "io.fluxhaus.FluxHaus", category: "Car")
                 let (_, response) = try await session.data(for: request)
                 let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
                 logger.info("Car action \(path) completed with HTTP \(statusCode)")
+                if (200...299).contains(statusCode) {
+                    await Self.donateCarIntent(
+                        action: action,
+                        defrost: defrost,
+                        heatedFeatures: steeringWheel,
+                        temperature: temperature
+                    )
+                }
             } catch {
                 logger.error("Car action \(path) failed: \(error.localizedDescription)")
             }
+        }
+    }
+
+    private static func donateCarIntent(
+        action: String,
+        defrost: Bool,
+        heatedFeatures: Bool,
+        temperature: Int?
+    ) async {
+        switch action {
+        case "lock":
+            try? await LockCarIntent().donate()
+        case "unlock":
+            try? await UnlockCarIntent().donate()
+        case "start":
+            let intent = StartCarClimateIntent()
+            intent.defrost = defrost
+            intent.heatedFeatures = heatedFeatures
+            intent.temperature = temperature
+            try? await intent.donate()
+        case "stop":
+            try? await StopCarClimateIntent().donate()
+        case "resync":
+            try? await ResyncCarIntent().donate()
+        default:
+            break
         }
     }
 }

--- a/Shared/Car.swift
+++ b/Shared/Car.swift
@@ -166,7 +166,7 @@ private let logger = Logger(subsystem: "io.fluxhaus.FluxHaus", category: "Car")
             try? await intent.donate()
         case "stop":
             try? await StopCarClimateIntent().donate()
-        case "resync":
+        case "resync", "rsync":
             try? await ResyncCarIntent().donate()
         default:
             break

--- a/Shared/Intents/AskFluxHausIntent.swift
+++ b/Shared/Intents/AskFluxHausIntent.swift
@@ -1,0 +1,45 @@
+//
+//  AskFluxHausIntent.swift
+//  FluxHaus
+//
+//  Free-text AI intent that routes a prompt to the FluxHaus assistant and speaks the answer.
+//
+
+import AppIntents
+
+struct AskFluxHausIntent: AppIntent {
+    static let title: LocalizedStringResource = "Ask FluxHaus"
+    static let description = IntentDescription("Ask the FluxHaus assistant about your home.")
+
+    @Parameter(title: "Question", requestValueDialog: "What would you like to ask FluxHaus?")
+    var prompt: String
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Ask FluxHaus \(\.$prompt)")
+    }
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        guard AuthManager.shared.isSignedIn else {
+            throw IntentError.notSignedIn
+        }
+
+        var answer = ""
+        var lastError: String?
+        for try await event in streamCommand(prompt) {
+            if event.type == "error" {
+                lastError = event.text
+                continue
+            }
+            if let text = event.text {
+                answer += text
+            }
+        }
+
+        let trimmed = answer.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            let message = lastError ?? "I didn't get a response. Please try again."
+            return .result(dialog: "\(message)")
+        }
+        return .result(dialog: "\(trimmed)")
+    }
+}

--- a/Shared/Intents/CarIntents.swift
+++ b/Shared/Intents/CarIntents.swift
@@ -1,0 +1,84 @@
+//
+//  CarIntents.swift
+//  FluxHaus
+//
+//  App Intents for controlling the FluxHaus car.
+//
+
+import AppIntents
+
+struct LockCarIntent: AppIntent {
+    static let title: LocalizedStringResource = "Lock Car"
+    static let description = IntentDescription("Lock the FluxHaus car.")
+
+    @MainActor
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        try await FluxIntentActions.lockCar()
+        return .result(dialog: "Locking the car.")
+    }
+}
+
+struct UnlockCarIntent: AppIntent {
+    static let title: LocalizedStringResource = "Unlock Car"
+    static let description = IntentDescription("Unlock the FluxHaus car.")
+
+    @MainActor
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        try await FluxIntentActions.unlockCar()
+        return .result(dialog: "Unlocking the car.")
+    }
+}
+
+struct StartCarClimateIntent: AppIntent {
+    static let title: LocalizedStringResource = "Start Car Climate"
+    static let description = IntentDescription("Start climate control in the FluxHaus car.")
+
+    @Parameter(title: "Defrost", default: false)
+    var defrost: Bool
+
+    @Parameter(title: "Heated Features", default: false)
+    var heatedFeatures: Bool
+
+    @Parameter(title: "Temperature")
+    var temperature: Int?
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Start car climate") {
+            \.$temperature
+            \.$defrost
+            \.$heatedFeatures
+        }
+    }
+
+    @MainActor
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        try await FluxIntentActions.startCarClimate(
+            defrost: defrost,
+            heatedFeatures: heatedFeatures,
+            temperature: temperature
+        )
+        return .result(dialog: "Starting the car's climate control.")
+    }
+}
+
+struct StopCarClimateIntent: AppIntent {
+    static let title: LocalizedStringResource = "Stop Car Climate"
+    static let description = IntentDescription("Stop climate control in the FluxHaus car.")
+
+    @MainActor
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        try await FluxIntentActions.stopCarClimate()
+        return .result(dialog: "Stopping the car's climate control.")
+    }
+}
+
+struct ResyncCarIntent: AppIntent {
+    static let title: LocalizedStringResource = "Resync Car"
+    static let description = IntentDescription("Refresh the FluxHaus car's status from the vehicle.")
+
+    @MainActor
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        try await FluxIntentActions.resyncCar()
+        return .result(dialog: "Resyncing the car.")
+    }
+}

--- a/Shared/Intents/FluxHausShortcuts.swift
+++ b/Shared/Intents/FluxHausShortcuts.swift
@@ -1,0 +1,104 @@
+//
+//  FluxHausShortcuts.swift
+//  FluxHaus
+//
+//  Exposes FluxHaus App Intents to Siri, Spotlight, and the Shortcuts app with
+//  spoken trigger phrases. Every phrase includes \(.applicationName) as required.
+//
+
+import AppIntents
+
+struct FluxHausShortcuts: AppShortcutsProvider {
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: AskFluxHausIntent(),
+            phrases: [
+                "Ask \(.applicationName)",
+                "Ask \(.applicationName) about my home"
+            ],
+            shortTitle: "Ask FluxHaus",
+            systemImageName: "sparkles"
+        )
+        AppShortcut(
+            intent: LockCarIntent(),
+            phrases: [
+                "Lock my car with \(.applicationName)",
+                "Lock the car in \(.applicationName)"
+            ],
+            shortTitle: "Lock Car",
+            systemImageName: "lock.fill"
+        )
+        AppShortcut(
+            intent: UnlockCarIntent(),
+            phrases: [
+                "Unlock my car with \(.applicationName)",
+                "Unlock the car in \(.applicationName)"
+            ],
+            shortTitle: "Unlock Car",
+            systemImageName: "lock.open.fill"
+        )
+        AppShortcut(
+            intent: StartCarClimateIntent(),
+            phrases: [
+                "Start my car's climate with \(.applicationName)",
+                "Warm up my car with \(.applicationName)"
+            ],
+            shortTitle: "Start Car Climate",
+            systemImageName: "thermometer.medium"
+        )
+        AppShortcut(
+            intent: StopCarClimateIntent(),
+            phrases: [
+                "Stop my car's climate with \(.applicationName)",
+                "Turn off my car's climate in \(.applicationName)"
+            ],
+            shortTitle: "Stop Car Climate",
+            systemImageName: "thermometer.snowflake"
+        )
+        AppShortcut(
+            intent: StartRobotIntent(),
+            phrases: [
+                "Start a robot with \(.applicationName)",
+                "Start cleaning with \(.applicationName)"
+            ],
+            shortTitle: "Start Robot",
+            systemImageName: "robotic.vacuum.cleaner"
+        )
+        AppShortcut(
+            intent: StopRobotIntent(),
+            phrases: [
+                "Stop a robot with \(.applicationName)",
+                "Stop cleaning with \(.applicationName)"
+            ],
+            shortTitle: "Stop Robot",
+            systemImageName: "robotic.vacuum.cleaner.fill"
+        )
+        AppShortcut(
+            intent: DeepCleanIntent(),
+            phrases: [
+                "Start a deep clean with \(.applicationName)",
+                "Deep clean with \(.applicationName)"
+            ],
+            shortTitle: "Deep Clean",
+            systemImageName: "sparkles"
+        )
+        AppShortcut(
+            intent: ActivateSceneIntent(),
+            phrases: [
+                "Activate a scene with \(.applicationName)",
+                "Run a \(.applicationName) scene"
+            ],
+            shortTitle: "Activate Scene",
+            systemImageName: "theatermasks.fill"
+        )
+        AppShortcut(
+            intent: CarStatusIntent(),
+            phrases: [
+                "What's my car status in \(.applicationName)",
+                "Check my car with \(.applicationName)"
+            ],
+            shortTitle: "Car Status",
+            systemImageName: "car.fill"
+        )
+    }
+}

--- a/Shared/Intents/FluxIntentActions.swift
+++ b/Shared/Intents/FluxIntentActions.swift
@@ -1,0 +1,131 @@
+//
+//  FluxIntentActions.swift
+//  FluxHaus
+//
+//  Shared async network helpers used by App Intents so that Siri / Apple Intelligence
+//  can report real success or failure. Unlike the fire-and-forget `performAction` methods
+//  on the @Observable device classes, these await the server response and throw on error.
+//
+
+import Foundation
+import os
+
+private let logger = Logger(subsystem: "io.fluxhaus.FluxHaus", category: "FluxIntentActions")
+
+enum IntentError: LocalizedError {
+    case notSignedIn
+    case requestFailed(Int)
+    case invalidURL
+
+    var errorDescription: String? {
+        switch self {
+        case .notSignedIn:
+            return "Please sign in to FluxHaus first."
+        case .requestFailed(let code):
+            return "The request failed (HTTP \(code))."
+        case .invalidURL:
+            return "Could not build the request."
+        }
+    }
+}
+
+enum FluxIntentActions {
+    static let scheme = "https"
+    static let host = "api.fluxhaus.io"
+
+    /// Performs an authenticated POST to the given API path and throws on a non-2xx response.
+    static func post(path: String, body: [String: Any]? = nil) async throws {
+        guard AuthManager.shared.isSignedIn else {
+            throw IntentError.notSignedIn
+        }
+
+        var components = URLComponents()
+        components.scheme = scheme
+        components.host = host
+        components.path = path
+        guard let url = components.url else {
+            throw IntentError.invalidURL
+        }
+
+        _ = await AuthManager.shared.ensureValidToken()
+        let csrfToken = await fetchCsrfToken()
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.addValue("application/json", forHTTPHeaderField: "Accept")
+        if let authHeader = AuthManager.shared.authorizationHeader() {
+            request.setValue(authHeader, forHTTPHeaderField: "Authorization")
+        } else {
+            throw IntentError.notSignedIn
+        }
+        if let csrfToken = csrfToken {
+            request.setValue(csrfToken, forHTTPHeaderField: "X-CSRF-Token")
+        }
+        if let body = body {
+            request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+        }
+
+        let session = URLSession(configuration: .default)
+        let (_, response) = try await session.data(for: request)
+        let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+        guard (200...299).contains(statusCode) else {
+            logger.error("Intent action \(path) failed with HTTP \(statusCode)")
+            throw IntentError.requestFailed(statusCode)
+        }
+        logger.info("Intent action \(path) completed with HTTP \(statusCode)")
+    }
+
+    // MARK: - Robots
+
+    static func startRobot(_ robot: RobotKind) async throws {
+        try await post(path: robot == .mopBot ? "/turnOnMopbot" : "/turnOnBroombot")
+    }
+
+    static func stopRobot(_ robot: RobotKind) async throws {
+        try await post(path: robot == .mopBot ? "/turnOffMopbot" : "/turnOffBroombot")
+    }
+
+    static func deepClean() async throws {
+        try await post(path: "/turnOnDeepClean")
+    }
+
+    // MARK: - Car
+
+    static func lockCar() async throws { try await post(path: "/lockCar") }
+    static func unlockCar() async throws { try await post(path: "/unlockCar") }
+    static func resyncCar() async throws { try await post(path: "/resyncCar") }
+    static func stopCarClimate() async throws { try await post(path: "/stopCar") }
+
+    static func startCarClimate(
+        defrost: Bool,
+        heatedFeatures: Bool,
+        temperature: Int?
+    ) async throws {
+        var body: [String: Any] = [
+            "heatedFeatures": heatedFeatures,
+            "seatFL": 0,
+            "seatFR": 0,
+            "seatRL": 0,
+            "seatRR": 0,
+            "defrost": defrost
+        ]
+        if let temperature = temperature {
+            body["temp"] = temperature
+        }
+        try await post(path: "/startCar", body: body)
+    }
+}
+
+/// The two robots FluxHaus controls. Shared by the action layer and the robot App Intents.
+enum RobotKind: String {
+    case broomBot
+    case mopBot
+
+    var displayName: String {
+        switch self {
+        case .broomBot: return "BroomBot"
+        case .mopBot: return "MopBot"
+        }
+    }
+}

--- a/Shared/Intents/RobotIntents.swift
+++ b/Shared/Intents/RobotIntents.swift
@@ -1,0 +1,74 @@
+//
+//  RobotIntents.swift
+//  FluxHaus
+//
+//  App Intents for controlling the BroomBot and MopBot robots.
+//
+
+import AppIntents
+
+enum RobotChoice: String, AppEnum {
+    case broomBot
+    case mopBot
+
+    static let typeDisplayRepresentation: TypeDisplayRepresentation = "Robot"
+
+    static let caseDisplayRepresentations: [RobotChoice: DisplayRepresentation] = [
+        .broomBot: "BroomBot",
+        .mopBot: "MopBot"
+    ]
+
+    var kind: RobotKind {
+        switch self {
+        case .broomBot: return .broomBot
+        case .mopBot: return .mopBot
+        }
+    }
+}
+
+struct StartRobotIntent: AppIntent {
+    static let title: LocalizedStringResource = "Start Robot"
+    static let description = IntentDescription("Start a FluxHaus cleaning robot.")
+
+    @Parameter(title: "Robot")
+    var robot: RobotChoice
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Start \(\.$robot)")
+    }
+
+    @MainActor
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        try await FluxIntentActions.startRobot(robot.kind)
+        return .result(dialog: "Starting \(robot.kind.displayName).")
+    }
+}
+
+struct StopRobotIntent: AppIntent {
+    static let title: LocalizedStringResource = "Stop Robot"
+    static let description = IntentDescription("Stop a FluxHaus cleaning robot.")
+
+    @Parameter(title: "Robot")
+    var robot: RobotChoice
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Stop \(\.$robot)")
+    }
+
+    @MainActor
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        try await FluxIntentActions.stopRobot(robot.kind)
+        return .result(dialog: "Stopping \(robot.kind.displayName).")
+    }
+}
+
+struct DeepCleanIntent: AppIntent {
+    static let title: LocalizedStringResource = "Start Deep Clean"
+    static let description = IntentDescription("Start a deep clean with the FluxHaus robots.")
+
+    @MainActor
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        try await FluxIntentActions.deepClean()
+        return .result(dialog: "Starting a deep clean.")
+    }
+}

--- a/Shared/Intents/SceneIntents.swift
+++ b/Shared/Intents/SceneIntents.swift
@@ -1,0 +1,96 @@
+//
+//  SceneIntents.swift
+//  FluxHaus
+//
+//  App Intent + entity for activating a HomeKit scene.
+//
+
+import AppIntents
+import CoreSpotlight
+import os
+
+struct SceneAppEntity: IndexedEntity {
+    // iOS 27 readiness note: SwiftUI's `.appEntityUIElements` contextual-cue modifier
+    // (annotating on-screen scenes so Siri can resolve "this scene") is not in the
+    // iOS 26 SDK. Adopt it behind an availability check once the SDK ships it. Until
+    // then, `EntityStringQuery` + Spotlight `IndexedEntity` provide name-based resolution.
+    let id: String
+
+    @Property(title: "Name")
+    var name: String
+
+    static let typeDisplayRepresentation: TypeDisplayRepresentation = "Scene"
+
+    var displayRepresentation: DisplayRepresentation {
+        DisplayRepresentation(title: "\(name)")
+    }
+
+    static let defaultQuery = SceneEntityQuery()
+
+    init(id: String, name: String) {
+        self.id = id
+        self.name = name
+    }
+
+    init(scene: HomeScene) {
+        self.id = scene.entityId
+        self.name = scene.name
+    }
+}
+
+/// Adds the app's HomeKit scenes to the Spotlight index so they're searchable and so
+/// Apple Intelligence / Siri can use them to fill in the Activate Scene intent.
+func indexScenes(_ scenes: [HomeScene]) async {
+    let entities = scenes.map(SceneAppEntity.init(scene:))
+    do {
+        try await CSSearchableIndex.default().indexAppEntities(entities)
+    } catch {
+        let logger = Logger(subsystem: "io.fluxhaus.FluxHaus", category: "SceneIndex")
+        logger.error("Failed to index scenes: \(error.localizedDescription)")
+    }
+}
+
+struct SceneEntityQuery: EntityStringQuery {
+    func entities(for identifiers: [SceneAppEntity.ID]) async throws -> [SceneAppEntity] {
+        let ids = Set(identifiers)
+        let scenes = try await fetchScenes()
+        return scenes
+            .filter { ids.contains($0.entityId) }
+            .map(SceneAppEntity.init(scene:))
+    }
+
+    /// Lets Siri / Apple Intelligence resolve a scene the user names out loud
+    /// (e.g. "activate the Good Morning scene").
+    func entities(matching string: String) async throws -> [SceneAppEntity] {
+        let needle = string.lowercased()
+        let scenes = try await fetchScenes()
+        return scenes
+            .filter { $0.name.lowercased().contains(needle) }
+            .map(SceneAppEntity.init(scene:))
+    }
+
+    func suggestedEntities() async throws -> [SceneAppEntity] {
+        let scenes = try await fetchScenes()
+        return scenes.map(SceneAppEntity.init(scene:))
+    }
+}
+
+struct ActivateSceneIntent: AppIntent {
+    static let title: LocalizedStringResource = "Activate Scene"
+    static let description = IntentDescription("Activate a FluxHaus HomeKit scene.")
+
+    @Parameter(title: "Scene")
+    var scene: SceneAppEntity
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Activate \(\.$scene)")
+    }
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        guard AuthManager.shared.isSignedIn else {
+            throw IntentError.notSignedIn
+        }
+        try await activateScene(entityId: scene.id)
+        return .result(dialog: "Activating \(scene.name).")
+    }
+}

--- a/Shared/Intents/StatusIntents.swift
+++ b/Shared/Intents/StatusIntents.swift
@@ -1,0 +1,109 @@
+//
+//  StatusIntents.swift
+//  FluxHaus
+//
+//  App Intents that report the current status of FluxHaus devices.
+//
+
+import AppIntents
+
+private func fetchStatus() async throws -> LoginResponse {
+    guard AuthManager.shared.isSignedIn else {
+        throw IntentError.notSignedIn
+    }
+    _ = await AuthManager.shared.ensureValidToken()
+    guard let response = try await getFlux(password: "") else {
+        throw IntentError.requestFailed(-1)
+    }
+    return response
+}
+
+struct CarStatusIntent: AppIntent {
+    static let title: LocalizedStringResource = "Car Status"
+    static let description = IntentDescription("Get the FluxHaus car's battery, range, and lock status.")
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        let response = try await fetchStatus()
+        guard let car = response.car, let evStatus = response.carEvStatus else {
+            return .result(dialog: "Car status isn't available right now.")
+        }
+        let range = evStatus.drvDistance.first?.rangeByFuel.evModeRange.value ?? 0
+        let locked = car.doorLock ? "locked" : "unlocked"
+        let climate = car.airCtrlOn ? " Climate control is on." : ""
+        return .result(dialog: """
+        The car is at \(evStatus.batteryStatus)% with about \(Int(range)) km of range, and it's \(locked).\(climate)
+        """)
+    }
+}
+
+struct RobotStatusIntent: AppIntent {
+    static let title: LocalizedStringResource = "Robot Status"
+    static let description = IntentDescription("Get the status of the FluxHaus cleaning robots.")
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        let response = try await fetchStatus()
+        return .result(dialog: "\(describe(response.broombot)) \(describe(response.mopbot))")
+    }
+
+    private func describe(_ robot: Robot) -> String {
+        let name = robot.name ?? "Robot"
+        let state: String
+        if robot.running == true {
+            state = "running"
+        } else if robot.docking == true || robot.charging == true {
+            state = "charging at the dock"
+        } else if robot.paused == true {
+            state = "paused"
+        } else {
+            state = "idle"
+        }
+        if let battery = robot.batteryLevel {
+            return "\(name) is \(state) at \(battery)%."
+        }
+        return "\(name) is \(state)."
+    }
+}
+
+struct ApplianceStatusIntent: AppIntent {
+    static let title: LocalizedStringResource = "Dishwasher Status"
+    static let description = IntentDescription("Get the status of the FluxHaus dishwasher.")
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        let response = try await fetchStatus()
+        guard let dishwasher = response.dishwasher else {
+            return .result(dialog: "Dishwasher status isn't available right now.")
+        }
+        let state = dishwasher.operationState.rawValue
+        if state == "Inactive" || state == "Finished" {
+            return .result(dialog: "The dishwasher is not running.")
+        }
+        if let remaining = dishwasher.remainingTime, remaining > 0 {
+            let minutes = remaining / 60
+            return .result(dialog: "The dishwasher is \(state) with about \(minutes) minutes remaining.")
+        }
+        return .result(dialog: "The dishwasher is \(state).")
+    }
+}
+
+struct ScooterStatusIntent: AppIntent {
+    static let title: LocalizedStringResource = "Scooter Status"
+    static let description = IntentDescription("Get the FluxHaus scooter's battery and range.")
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        let response = try await fetchStatus()
+        guard let scooter = response.scooter else {
+            return .result(dialog: "Scooter status isn't available right now.")
+        }
+        var parts: [String] = []
+        if let battery = scooter.battery {
+            parts.append("\(battery)% battery")
+        }
+        if let range = scooter.estimatedRange {
+            parts.append("about \(Int(range)) km of range")
+        }
+        if parts.isEmpty {
+            return .result(dialog: "Scooter status isn't available right now.")
+        }
+        return .result(dialog: "The scooter has \(parts.joined(separator: " and ")).")
+    }
+}

--- a/Shared/Intents/StatusIntents.swift
+++ b/Shared/Intents/StatusIntents.swift
@@ -11,7 +11,10 @@ private func fetchStatus() async throws -> LoginResponse {
     guard AuthManager.shared.isSignedIn else {
         throw IntentError.notSignedIn
     }
-    _ = await AuthManager.shared.ensureValidToken()
+    guard await AuthManager.shared.ensureValidToken(),
+          AuthManager.shared.authorizationHeader() != nil else {
+        throw IntentError.notSignedIn
+    }
     guard let response = try await getFlux(password: "") else {
         throw IntentError.requestFailed(-1)
     }

--- a/Shared/Robots.swift
+++ b/Shared/Robots.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import AppIntents
 import os
 
 private let logger = Logger(subsystem: "io.fluxhaus.FluxHaus", category: "Robots")
@@ -116,9 +117,30 @@ private let logger = Logger(subsystem: "io.fluxhaus.FluxHaus", category: "Robots
                 let (_, response) = try await session.data(for: request)
                 let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
                 logger.info("Robot action \(path) completed with HTTP \(statusCode)")
+                if (200...299).contains(statusCode) {
+                    await Self.donateRobotIntent(action: action, robot: robot)
+                }
             } catch {
                 logger.error("Robot action \(path) failed: \(error.localizedDescription)")
             }
+        }
+    }
+
+    private static func donateRobotIntent(action: String, robot: String) async {
+        let choice: RobotChoice = robot == "MopBot" ? .mopBot : .broomBot
+        switch action {
+        case "start":
+            let intent = StartRobotIntent()
+            intent.robot = choice
+            try? await intent.donate()
+        case "stop":
+            let intent = StopRobotIntent()
+            intent.robot = choice
+            try? await intent.donate()
+        case "deepClean":
+            try? await DeepCleanIntent().donate()
+        default:
+            break
         }
     }
 }

--- a/Shared/SceneView.swift
+++ b/Shared/SceneView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import AppIntents
 import os
 
 private let logger = Logger(
@@ -24,6 +25,7 @@ private let logger = Logger(
         do {
             scenes = try await fetchScenes()
             loadError = nil
+            await indexScenes(scenes)
             if favouriteNames.isEmpty {
                 favourites = []
             } else {
@@ -51,6 +53,9 @@ private let logger = Logger(
             do {
                 try await activateScene(entityId: scene.entityId)
                 logger.info("Scene activated: \(scene.name)")
+                let intent = ActivateSceneIntent()
+                intent.scene = SceneAppEntity(scene: scene)
+                try? await intent.donate()
             } catch {
                 logger.error("Scene activation failed: \(error.localizedDescription)")
             }

--- a/Shared/SceneView.swift
+++ b/Shared/SceneView.swift
@@ -20,12 +20,19 @@ private let logger = Logger(
     var activatingSceneId: String?
     var loadError: String?
     var hasLoaded = false
+    private var indexedSceneIds: Set<String> = []
 
     func loadScenes(favouriteNames: [String]) async {
         do {
             scenes = try await fetchScenes()
             loadError = nil
-            await indexScenes(scenes)
+            // Only re-index Spotlight when the set of scenes actually changes, so the
+            // periodic refresh timer doesn't re-index on every tick.
+            let currentIds = Set(scenes.map { $0.entityId })
+            if currentIds != indexedSceneIds {
+                await indexScenes(scenes)
+                indexedSceneIds = currentIds
+            }
             if favouriteNames.isEmpty {
                 favourites = []
             } else {

--- a/SharedTests/AppIntentsTests.swift
+++ b/SharedTests/AppIntentsTests.swift
@@ -1,0 +1,40 @@
+//
+//  AppIntentsTests.swift
+//  FluxHaus Tests
+//
+//  Unit tests for the pure logic in the FluxHaus App Intents layer.
+//
+
+import Testing
+import Foundation
+@testable import FluxHaus
+
+struct AppIntentsTests {
+
+    @Test("RobotChoice maps to the matching RobotKind")
+    func robotChoiceMapsToKind() {
+        #expect(RobotChoice.broomBot.kind == .broomBot)
+        #expect(RobotChoice.mopBot.kind == .mopBot)
+    }
+
+    @Test("RobotKind exposes the expected display names")
+    func robotKindDisplayNames() {
+        #expect(RobotKind.broomBot.displayName == "BroomBot")
+        #expect(RobotKind.mopBot.displayName == "MopBot")
+    }
+
+    @Test("SceneAppEntity is built from a HomeScene")
+    func sceneEntityFromHomeScene() {
+        let scene = HomeScene(entityId: "scene.movie_night", name: "Movie Night", isActive: false)
+        let entity = SceneAppEntity(scene: scene)
+        #expect(entity.id == "scene.movie_night")
+        #expect(entity.name == "Movie Night")
+    }
+
+    @Test("IntentError provides user-facing descriptions")
+    func intentErrorDescriptions() {
+        #expect(IntentError.notSignedIn.errorDescription == "Please sign in to FluxHaus first.")
+        #expect(IntentError.requestFailed(503).errorDescription == "The request failed (HTTP 503).")
+        #expect(IntentError.invalidURL.errorDescription == "Could not build the request.")
+    }
+}


### PR DESCRIPTION
## Summary
Adds first-class **App Intents** so FluxHaus device controls, status queries, and the AI assistant are usable from **Siri, Apple Intelligence, Spotlight, and the Shortcuts app** across **iOS, VisionOS, and macOS**.

## What's included
- **Robot intents**: start / stop / deep-clean (BroomBot & MopBot)
- **Car intents**: lock / unlock / start-climate (defrost, heated features, optional temperature) / stop-climate / resync
- **Scene intent**: activate a HomeKit scene via a dynamic `EntityStringQuery` (resolvable by name)
- **Status intents**: car, robot, appliance, scooter
- **Ask FluxHaus AI intent**: free-text prompt → `/command/stream` aggregation
- **AppShortcutsProvider** with 10 phrased Siri shortcuts
- **Spotlight**: `SceneAppEntity` conforms to `IndexedEntity`; scenes indexed on load
- **Donations**: car/robot/scene intents donate after successful in-app actions for Siri Suggestions/predictions

## Architecture
- Nonisolated async action layer (`FluxIntentActions`) so `perform()` can await network results and report success/failure to Siri.
- Intents reuse `AuthManager.shared` (token/keychain) and throw a friendly "sign in" error when signed out.
- Intent files live in `Shared/Intents/` and are compiled into the three app targets. Because the shared `Car.swift`/`Robots.swift` files (which the widget extension also compiles) now donate intents after successful actions, the widget target additionally compiles `FluxIntentActions.swift`, `RobotIntents.swift`, and `CarIntents.swift`. The widget still only *uses* its existing `ConfigurationAppIntent`; the extra intent sources are compiled but not surfaced by the widget.

## iOS 26 → 27 readiness
- No App Intents **schema domain** matches FluxHaus's smart-home actions (no HomeKit/smart-home domain), so custom intents are used intentionally rather than force-fitting a mismatched schema.
- The iOS 27 `.appEntityUIElements` contextual-cue API is **not in the iOS 26 SDK**; it's documented to be adopted behind an availability check once shipped. `EntityStringQuery` + Spotlight indexing provide name-based resolution today.

## Validation
- ✅ Builds: `FluxHaus (iOS)`, `VisionOS`, `FluxHaus (macOS)`
- ✅ `swiftlint --strict` — 0 violations
- ✅ `VisionOSTests/AppIntentsTests` — all pass