### PR TITLE
fix: improve chat paste handling, tabs, and window management

### DIFF
--- a/FluxHaus.xcodeproj/project.pbxproj
+++ b/FluxHaus.xcodeproj/project.pbxproj
@@ -1531,7 +1531,7 @@
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.13;
+				MARKETING_VERSION = 1.8.14;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.davidjensenius.FluxHaus.Tests-macOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
@@ -1597,7 +1597,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.13;
+				MARKETING_VERSION = 1.8.14;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -1658,7 +1658,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.13;
+				MARKETING_VERSION = 1.8.14;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -1686,7 +1686,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.13;
+				MARKETING_VERSION = 1.8.14;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus;
 				PRODUCT_NAME = FluxHaus;
 				SDKROOT = iphoneos;
@@ -1719,7 +1719,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.13;
+				MARKETING_VERSION = 1.8.14;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus;
 				PRODUCT_NAME = FluxHaus;
 				SDKROOT = iphoneos;
@@ -1748,7 +1748,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.13;
+				MARKETING_VERSION = 1.8.14;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.davidjensenius.Tests-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1775,7 +1775,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.13;
+				MARKETING_VERSION = 1.8.14;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.davidjensenius.Tests-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1814,7 +1814,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.8.13;
+				MARKETING_VERSION = 1.8.14;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus.FluxWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1853,7 +1853,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.8.13;
+				MARKETING_VERSION = 1.8.14;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus.FluxWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1890,7 +1890,7 @@
 					"@executable_path/Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.8.13;
+				MARKETING_VERSION = 1.8.14;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus;
 				PRODUCT_MODULE_NAME = FluxHaus;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1928,7 +1928,7 @@
 					"@executable_path/Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.8.13;
+				MARKETING_VERSION = 1.8.14;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus;
 				PRODUCT_MODULE_NAME = FluxHaus;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1954,7 +1954,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.8.13;
+				MARKETING_VERSION = 1.8.14;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jensenius.fluxhaus.VisionOSTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = xros;
@@ -1980,7 +1980,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.8.13;
+				MARKETING_VERSION = 1.8.14;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jensenius.fluxhaus.VisionOSTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = xros;
@@ -2027,7 +2027,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.13;
+				MARKETING_VERSION = 1.8.14;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus;
 				PRODUCT_NAME = FluxHaus;
 				SDKROOT = macosx;
@@ -2067,7 +2067,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.13;
+				MARKETING_VERSION = 1.8.14;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus;
 				PRODUCT_NAME = FluxHaus;
 				SDKROOT = macosx;
@@ -2083,7 +2083,7 @@
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.8.13;
+				MARKETING_VERSION = 1.8.14;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.davidjensenius.FluxHaus.Tests-macOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;

--- a/Shared/Chat.swift
+++ b/Shared/Chat.swift
@@ -39,6 +39,68 @@ struct ChatImage: Identifiable {
     }
 }
 
+/// A large chunk of pasted text represented as a composer attachment.
+///
+/// Emulates ChatGPT/Claude behaviour: rather than dumping a big paste inline into
+/// the text field, it is shown as a collapsible chip. On send the content is inlined
+/// into the outgoing command wrapped in a fenced code block (see `Chat.send`).
+struct PastedTextAttachment: Identifiable, Equatable {
+    let id = UUID()
+    let text: String
+
+    /// Number of characters that triggers converting a paste into an attachment.
+    static let characterThreshold = 600
+    /// Number of newlines that triggers converting a paste into an attachment.
+    static let lineThreshold = 15
+
+    var charCount: Int { text.count }
+
+    var lineCount: Int {
+        guard !text.isEmpty else { return 0 }
+        return text.reduce(1) { $1 == "\n" ? $0 + 1 : $0 }
+    }
+
+    /// Short single-line preview used on the chip.
+    var preview: String {
+        let firstLine = text
+            .split(separator: "\n", maxSplits: 1, omittingEmptySubsequences: false)
+            .first
+            .map(String.init) ?? text
+        let trimmed = firstLine.trimmingCharacters(in: .whitespaces)
+        if trimmed.count > 48 {
+            return String(trimmed.prefix(48)) + "…"
+        }
+        return trimmed.isEmpty ? "Pasted text" : trimmed
+    }
+
+    /// Whether a freshly pasted string is large enough to become an attachment.
+    static func qualifies(_ candidate: String) -> Bool {
+        if candidate.count >= characterThreshold { return true }
+        let newlines = candidate.reduce(0) { $1 == "\n" ? $0 + 1 : $0 }
+        return newlines + 1 >= lineThreshold
+    }
+
+    /// Detects a single large insertion between two composer states (typically caused
+    /// by a paste). Returns the text with the inserted chunk removed and the chunk
+    /// itself, or `nil` when no qualifying insertion is found.
+    static func detectLargeInsertion(old: String, new: String) -> (remaining: String, inserted: String)? {
+        guard new.count > old.count else { return nil }
+        let prefix = new.commonPrefix(with: old)
+        let oldSuffix = old.dropFirst(prefix.count)
+        let newSuffix = new.dropFirst(prefix.count)
+        let suffixLength = zip(oldSuffix.reversed(), newSuffix.reversed())
+            .prefix { $0 == $1 }
+            .count
+        let insertedStart = new.index(new.startIndex, offsetBy: prefix.count)
+        let insertedEnd = new.index(new.endIndex, offsetBy: -suffixLength)
+        guard insertedStart < insertedEnd else { return nil }
+        let inserted = String(new[insertedStart..<insertedEnd])
+        guard qualifies(inserted) else { return nil }
+        let remaining = String(new[..<insertedStart]) + String(new[insertedEnd...])
+        return (remaining, inserted)
+    }
+}
+
 struct ChatMessage: Identifiable {
     let id: UUID
     let role: ChatRole
@@ -114,6 +176,10 @@ struct Conversation: Identifiable, Codable {
     var playingMessageId: UUID?
     var sessionError: String?
     var conversations: [Conversation] = []
+    /// Ordered list of conversation ids kept open as in-app tabs. The active tab is
+    /// `conversationId`. A brand-new (unsaved) conversation is represented by
+    /// `conversationId == nil` and shown as a transient "New" tab in the UI.
+    var openConversationTabs: [String] = []
     private(set) var cachedConversationIds: [String] = []
     private var cachedMessages: [String: [ChatMessage]] = [:]
     private let maxCachedConversations = 5
@@ -160,9 +226,39 @@ struct Conversation: Identifiable, Codable {
     private var isSyncing = false
     private var loadingConversationIds: Set<String> = []
 
-    func send(_ text: String, images: [ChatImage] = []) async {
-        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return }
+    /// Builds the outgoing command text by appending each pasted-text attachment as a
+    /// fenced code block after the typed message. Uses a fence long enough to safely
+    /// wrap content that itself contains backtick fences.
+    static func composeCommand(text: String, pastedTexts: [PastedTextAttachment]) -> String {
+        let base = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !pastedTexts.isEmpty else { return base }
+        var parts: [String] = base.isEmpty ? [] : [base]
+        for pasted in pastedTexts {
+            let fenceLength = max(3, longestBacktickRun(in: pasted.text) + 1)
+            let fence = String(repeating: "`", count: fenceLength)
+            parts.append("\(fence)\n\(pasted.text)\n\(fence)")
+        }
+        return parts.joined(separator: "\n\n")
+    }
+
+    private static func longestBacktickRun(in text: String) -> Int {
+        var longest = 0
+        var current = 0
+        for char in text {
+            if char == "`" {
+                current += 1
+                longest = max(longest, current)
+            } else {
+                current = 0
+            }
+        }
+        return longest
+    }
+
+    func send(_ text: String, images: [ChatImage] = [], pastedTexts: [PastedTextAttachment] = []) async {
+        let composed = Chat.composeCommand(text: text, pastedTexts: pastedTexts)
+        let trimmed = composed.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty || !images.isEmpty else { return }
 
         guard await ensureConversation() else {
             cleanupRecording()
@@ -504,6 +600,7 @@ extension Chat {
     func loadConversation(_ conv: Conversation) async {
         touchConversation(conv.id)
         conversationId = conv.id
+        openTab(for: conv.id)
         if cachedMessages[conv.id] != nil {
             refreshLoadingState()
             return
@@ -544,6 +641,7 @@ extension Chat {
             conversations.removeAll { $0.id == conv.id }
             cachedMessages.removeValue(forKey: conv.id)
             cachedConversationIds.removeAll { $0 == conv.id }
+            openConversationTabs.removeAll { $0 == conv.id }
             loadingConversationIds.remove(conv.id)
             if conversationId == conv.id {
                 // Select next available conversation instead of creating a new one
@@ -559,6 +657,56 @@ extension Chat {
         }
     }
 
+    // MARK: - Conversation tabs
+
+    /// Conversations currently open as tabs, in tab order.
+    var openTabConversations: [Conversation] {
+        openConversationTabs.compactMap { id in
+            conversations.first(where: { $0.id == id })
+        }
+    }
+
+    /// Adds a conversation id to the open-tab list if not already present.
+    func openTab(for id: String) {
+        if !openConversationTabs.contains(id) {
+            openConversationTabs.append(id)
+        }
+    }
+
+    /// Selects an open tab, loading its conversation.
+    func selectTab(_ id: String) async {
+        guard let conv = conversations.first(where: { $0.id == id }) else { return }
+        await loadConversation(conv)
+    }
+
+    /// Closes a tab. If it was active, activates a neighbouring tab (or a new chat).
+    func closeTab(_ id: String) async {
+        guard let index = openConversationTabs.firstIndex(of: id) else { return }
+        openConversationTabs.remove(at: index)
+        guard conversationId == id else { return }
+        if openConversationTabs.isEmpty {
+            startNewConversation()
+            return
+        }
+        let neighbour = openConversationTabs[min(index, openConversationTabs.count - 1)]
+        await selectTab(neighbour)
+    }
+
+    /// Cycles the active tab forward/backward through the open tabs. When on the
+    /// transient new-chat tab, cycles into the first/last open tab.
+    func cycleTab(forward: Bool) async {
+        guard !openConversationTabs.isEmpty else { return }
+        guard let current = conversationId,
+              let index = openConversationTabs.firstIndex(of: current) else {
+            let target = forward ? openConversationTabs.first : openConversationTabs.last
+            if let target { await selectTab(target) }
+            return
+        }
+        let count = openConversationTabs.count
+        let nextIndex = ((index + (forward ? 1 : -1)) % count + count) % count
+        await selectTab(openConversationTabs[nextIndex])
+    }
+
 }
 
 extension Chat {
@@ -571,6 +719,7 @@ extension Chat {
             let conv = try await createConversation()
             conversationId = conv.id
             touchConversation(conv.id)
+            openTab(for: conv.id)
             conversations.insert(conv, at: 0)
             sessionError = nil
             return true

--- a/Shared/Chat.swift
+++ b/Shared/Chat.swift
@@ -50,7 +50,7 @@ struct PastedTextAttachment: Identifiable, Equatable {
 
     /// Number of characters that triggers converting a paste into an attachment.
     static let characterThreshold = 600
-    /// Number of newlines that triggers converting a paste into an attachment.
+    /// Number of lines that triggers converting a paste into an attachment.
     static let lineThreshold = 15
 
     var charCount: Int { text.count }

--- a/Shared/ChatBubble.swift
+++ b/Shared/ChatBubble.swift
@@ -5,7 +5,14 @@
 //  Created by David Jensenius on 2026-03-13.
 //
 
+// swiftlint:disable file_length
+
 import SwiftUI
+#if canImport(UIKit)
+import UIKit
+#elseif canImport(AppKit)
+import AppKit
+#endif
 
 // MARK: - Bubble shape
 
@@ -175,6 +182,396 @@ struct ChatBubble: View {
             : Theme.Colors.accent
     }
 }
+
+// MARK: - Conversation tab bar (shared)
+
+/// Horizontal strip of open conversation tabs used on iOS and VisionOS. Shows each
+/// open conversation, a transient "New Chat" tab when the active conversation is
+/// unsaved, and a button to open a new tab.
+struct ConversationTabBar: View {
+    @Bindable var chat: Chat
+
+    var body: some View {
+        let tabs = chat.openTabConversations
+        let showNewTab = chat.conversationId == nil
+        if !tabs.isEmpty || showNewTab {
+            VStack(spacing: 0) {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 6) {
+                        ForEach(tabs) { conv in
+                            tabChip(
+                                title: conv.title ?? "Untitled",
+                                isActive: conv.id == chat.conversationId,
+                                onSelect: { Task { await chat.selectTab(conv.id) } },
+                                onClose: { Task { await chat.closeTab(conv.id) } }
+                            )
+                        }
+                        if showNewTab {
+                            tabChip(title: "New Chat", isActive: true, onSelect: {}, onClose: nil)
+                        }
+                        Button(action: { chat.startNewConversation() }, label: {
+                            Image(systemName: "plus")
+                                .font(Theme.Fonts.caption)
+                                .foregroundColor(Theme.Colors.accent)
+                        })
+                        .buttonStyle(.plain)
+                    }
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                }
+                Divider()
+            }
+        }
+    }
+
+    private func tabChip(
+        title: String,
+        isActive: Bool,
+        onSelect: @escaping () -> Void,
+        onClose: (() -> Void)?
+    ) -> some View {
+        HStack(spacing: 6) {
+            Text(title)
+                .font(Theme.Fonts.caption.weight(isActive ? .semibold : .regular))
+                .foregroundColor(isActive ? Theme.Colors.textPrimary : Theme.Colors.textSecondary)
+                .lineLimit(1)
+            if let onClose {
+                Button(action: onClose, label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 9, weight: .bold))
+                        .foregroundColor(Theme.Colors.textSecondary)
+                })
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .frame(maxWidth: 180)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(isActive ? Theme.Colors.accent.opacity(0.15) : Color.clear)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(
+                    isActive ? Theme.Colors.accent.opacity(0.4) : Theme.Colors.textSecondary.opacity(0.2),
+                    lineWidth: 1
+                )
+        )
+        .contentShape(Rectangle())
+        .onTapGesture(perform: onSelect)
+    }
+}
+
+// MARK: - Pasted text attachment chip
+
+/// Compact composer chip representing a large pasted-text attachment.
+struct PastedTextChip: View {
+    let attachment: PastedTextAttachment
+    let onTap: () -> Void
+    let onRemove: () -> Void
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "doc.text.fill")
+                .font(Theme.Fonts.bodyMedium)
+                .foregroundColor(Theme.Colors.accent)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Pasted text")
+                    .font(Theme.Fonts.caption.weight(.semibold))
+                    .foregroundColor(Theme.Colors.textPrimary)
+                Text("\(attachment.lineCount) lines · \(attachment.charCount) chars")
+                    .font(Theme.Fonts.caption)
+                    .foregroundColor(Theme.Colors.textSecondary)
+                    .lineLimit(1)
+            }
+            Button(action: onRemove) {
+                Image(systemName: "xmark.circle.fill")
+                    .font(Theme.Fonts.bodyMedium)
+                    .foregroundColor(Theme.Colors.textSecondary)
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(Theme.Colors.secondaryBackground)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(Theme.Colors.accent.opacity(0.2), lineWidth: 1)
+        )
+        .contentShape(Rectangle())
+        .onTapGesture(perform: onTap)
+    }
+}
+
+/// Full-content viewer for a pasted-text attachment, shown in a sheet.
+struct PastedTextDetailView: View {
+    let attachment: PastedTextAttachment
+    var onDismiss: () -> Void
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                Text(attachment.text)
+                    .font(.system(.body, design: .monospaced))
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding()
+            }
+            .navigationTitle("Pasted Text")
+            #if os(iOS) || os(visionOS)
+            .navigationBarTitleDisplayMode(.inline)
+            #endif
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done", action: onDismiss)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Paste-intercepting composer text field
+
+/// A multiline composer text field that intercepts large clipboard pastes before
+/// they enter the editor (mirroring ChatGPT/Claude) and forwards them as
+/// `PastedTextAttachment`s instead. Small pastes and normal typing behave as usual.
+struct ChatComposerTextField: View {
+    @Binding var text: String
+    var placeholder: String = "Ask anything…"
+    var focusOnAppear: Bool = false
+    var onSubmit: () -> Void
+    var onPasteLargeText: (String) -> Void
+
+    @State private var measuredHeight: CGFloat = 0
+
+    #if os(macOS)
+    private let minHeight: CGFloat = 22
+    private let maxHeight: CGFloat = 200
+    #else
+    private let minHeight: CGFloat = 30
+    private let maxHeight: CGFloat = 240
+    #endif
+
+    var body: some View {
+        ComposerTextView(
+            text: $text,
+            measuredHeight: $measuredHeight,
+            placeholder: placeholder,
+            focusOnAppear: focusOnAppear,
+            onSubmit: onSubmit,
+            onPasteLargeText: onPasteLargeText
+        )
+        .frame(height: min(max(measuredHeight, minHeight), maxHeight))
+    }
+}
+
+#if canImport(UIKit)
+final class PasteInterceptingTextView: UITextView {
+    var onPasteLargeText: ((String) -> Void)?
+
+    override func paste(_ sender: Any?) {
+        if let string = UIPasteboard.general.string, PastedTextAttachment.qualifies(string) {
+            onPasteLargeText?(string)
+            return
+        }
+        super.paste(sender)
+    }
+}
+
+struct ComposerTextView: UIViewRepresentable {
+    @Binding var text: String
+    @Binding var measuredHeight: CGFloat
+    var placeholder: String
+    var focusOnAppear: Bool
+    var onSubmit: () -> Void
+    var onPasteLargeText: (String) -> Void
+
+    func makeUIView(context: Context) -> PasteInterceptingTextView {
+        let view = PasteInterceptingTextView()
+        view.delegate = context.coordinator
+        view.font = UIFont.systemFont(ofSize: 18)
+        view.backgroundColor = .clear
+        view.textContainerInset = UIEdgeInsets(top: 6, left: 0, bottom: 6, right: 0)
+        view.textContainer.lineFragmentPadding = 0
+        view.isScrollEnabled = true
+        view.textColor = UIColor(Theme.Colors.textPrimary)
+        view.onPasteLargeText = onPasteLargeText
+        view.text = text
+
+        let label = UILabel()
+        label.text = placeholder
+        label.font = view.font
+        label.textColor = .placeholderText
+        label.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(label)
+        NSLayoutConstraint.activate([
+            label.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            label.topAnchor.constraint(equalTo: view.topAnchor, constant: 6)
+        ])
+        context.coordinator.placeholderLabel = label
+        label.isHidden = !text.isEmpty
+
+        if focusOnAppear {
+            DispatchQueue.main.async { view.becomeFirstResponder() }
+        }
+        return view
+    }
+
+    func updateUIView(_ uiView: PasteInterceptingTextView, context: Context) {
+        if uiView.text != text {
+            uiView.text = text
+            context.coordinator.placeholderLabel?.isHidden = !text.isEmpty
+        }
+        uiView.onPasteLargeText = onPasteLargeText
+        let height = uiView.contentSize.height
+        if abs(height - measuredHeight) > 0.5 {
+            DispatchQueue.main.async { measuredHeight = height }
+        }
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator(self) }
+
+    final class Coordinator: NSObject, UITextViewDelegate {
+        var parent: ComposerTextView
+        weak var placeholderLabel: UILabel?
+        init(_ parent: ComposerTextView) { self.parent = parent }
+
+        func textViewDidChange(_ textView: UITextView) {
+            parent.text = textView.text
+            placeholderLabel?.isHidden = !textView.text.isEmpty
+            parent.measuredHeight = textView.contentSize.height
+        }
+
+        func textView(
+            _ textView: UITextView,
+            shouldChangeTextIn range: NSRange,
+            replacementText text: String
+        ) -> Bool {
+            if text == "\n" {
+                parent.onSubmit()
+                return false
+            }
+            return true
+        }
+    }
+}
+#elseif canImport(AppKit)
+final class PasteInterceptingTextView: NSTextView {
+    var onPasteLargeText: ((String) -> Void)?
+    var placeholderString: String?
+
+    override func paste(_ sender: Any?) {
+        if let string = NSPasteboard.general.string(forType: .string),
+           PastedTextAttachment.qualifies(string) {
+            onPasteLargeText?(string)
+            return
+        }
+        super.paste(sender)
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+        guard string.isEmpty, let placeholderString, !placeholderString.isEmpty else { return }
+        let attrs: [NSAttributedString.Key: Any] = [
+            .foregroundColor: NSColor.placeholderTextColor,
+            .font: font ?? NSFont.systemFont(ofSize: 15)
+        ]
+        placeholderString.draw(
+            at: NSPoint(x: textContainerInset.width, y: textContainerInset.height),
+            withAttributes: attrs
+        )
+    }
+}
+
+struct ComposerTextView: NSViewRepresentable {
+    @Binding var text: String
+    @Binding var measuredHeight: CGFloat
+    var placeholder: String
+    var focusOnAppear: Bool
+    var onSubmit: () -> Void
+    var onPasteLargeText: (String) -> Void
+
+    func makeNSView(context: Context) -> NSScrollView {
+        let scrollView = NSScrollView()
+        scrollView.drawsBackground = false
+        scrollView.hasVerticalScroller = false
+        scrollView.borderType = .noBorder
+
+        let textView = PasteInterceptingTextView()
+        textView.delegate = context.coordinator
+        textView.font = NSFont.systemFont(ofSize: 15)
+        textView.drawsBackground = false
+        textView.textColor = NSColor(Theme.Colors.textPrimary)
+        textView.isRichText = false
+        textView.isVerticallyResizable = true
+        textView.isHorizontallyResizable = false
+        textView.textContainerInset = NSSize(width: 0, height: 6)
+        textView.textContainer?.lineFragmentPadding = 0
+        textView.textContainer?.widthTracksTextView = true
+        textView.autoresizingMask = [.width]
+        textView.onPasteLargeText = onPasteLargeText
+        textView.placeholderString = placeholder
+        textView.string = text
+
+        scrollView.documentView = textView
+        context.coordinator.textView = textView
+
+        if focusOnAppear {
+            DispatchQueue.main.async { textView.window?.makeFirstResponder(textView) }
+        }
+        return scrollView
+    }
+
+    func updateNSView(_ nsView: NSScrollView, context: Context) {
+        guard let textView = nsView.documentView as? PasteInterceptingTextView else { return }
+        if textView.string != text {
+            textView.string = text
+            textView.needsDisplay = true
+        }
+        textView.onPasteLargeText = onPasteLargeText
+        context.coordinator.recalcHeight()
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator(self) }
+
+    final class Coordinator: NSObject, NSTextViewDelegate {
+        var parent: ComposerTextView
+        weak var textView: NSTextView?
+        init(_ parent: ComposerTextView) { self.parent = parent }
+
+        func textDidChange(_ notification: Notification) {
+            guard let textView = notification.object as? NSTextView else { return }
+            parent.text = textView.string
+            textView.needsDisplay = true
+            recalcHeight()
+        }
+
+        func textView(_ textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
+            if commandSelector == #selector(NSResponder.insertNewline(_:)) {
+                parent.onSubmit()
+                return true
+            }
+            return false
+        }
+
+        func recalcHeight() {
+            guard let textView, let container = textView.textContainer,
+                  let layoutManager = textView.layoutManager else { return }
+            layoutManager.ensureLayout(for: container)
+            let used = layoutManager.usedRect(for: container).height
+            let height = used + textView.textContainerInset.height * 2
+            let binding = parent.$measuredHeight
+            if abs(height - binding.wrappedValue) > 0.5 {
+                DispatchQueue.main.async { binding.wrappedValue = height }
+            }
+        }
+    }
+}
+#endif
 
 #if DEBUG
 #Preview {

--- a/SharedTests/ChatTranscriptRendererTests.swift
+++ b/SharedTests/ChatTranscriptRendererTests.swift
@@ -99,7 +99,7 @@ struct PastedTextAttachmentTests {
     func detectsLargeInsertion() throws {
         let pasted = String(repeating: "z", count: 700)
         let result = try #require(
-            PastedTextAttachment.detectLargeInsertion(old: "Hi ", new: "Hi \(pasted)!")
+            PastedTextAttachment.detectLargeInsertion(old: "Hi !", new: "Hi \(pasted)!")
         )
         #expect(result.inserted == pasted)
         #expect(result.remaining == "Hi !")

--- a/SharedTests/ChatTranscriptRendererTests.swift
+++ b/SharedTests/ChatTranscriptRendererTests.swift
@@ -77,3 +77,66 @@ struct ChatTranscriptRendererTests {
         )
     }
 }
+
+struct PastedTextAttachmentTests {
+
+    @Test("Long text qualifies as a pasted attachment")
+    func longTextQualifies() {
+        let long = String(repeating: "a", count: 600)
+        #expect(PastedTextAttachment.qualifies(long))
+        #expect(!PastedTextAttachment.qualifies("short"))
+    }
+
+    @Test("Many lines qualify as a pasted attachment")
+    func manyLinesQualify() {
+        let manyLines = Array(repeating: "x", count: 15).joined(separator: "\n")
+        #expect(PastedTextAttachment.qualifies(manyLines))
+        let fewLines = Array(repeating: "x", count: 3).joined(separator: "\n")
+        #expect(!PastedTextAttachment.qualifies(fewLines))
+    }
+
+    @Test("Detects a large insertion and strips it from the remaining text")
+    func detectsLargeInsertion() throws {
+        let pasted = String(repeating: "z", count: 700)
+        let result = try #require(
+            PastedTextAttachment.detectLargeInsertion(old: "Hi ", new: "Hi \(pasted)!")
+        )
+        #expect(result.inserted == pasted)
+        #expect(result.remaining == "Hi !")
+    }
+
+    @Test("Ignores small insertions")
+    func ignoresSmallInsertion() {
+        #expect(PastedTextAttachment.detectLargeInsertion(old: "Hi", new: "Hi there") == nil)
+    }
+
+    @Test("Line and character counts are accurate")
+    func countsAreAccurate() {
+        let attachment = PastedTextAttachment(text: "one\ntwo\nthree")
+        #expect(attachment.lineCount == 3)
+        #expect(attachment.charCount == 13)
+    }
+}
+
+@MainActor
+struct ChatComposeCommandTests {
+
+    @Test("Composes typed text with fenced pasted attachments")
+    func composesFencedAttachments() {
+        let pasted = PastedTextAttachment(text: "let x = 1")
+        let composed = Chat.composeCommand(text: "Review this", pastedTexts: [pasted])
+        #expect(composed == "Review this\n\n```\nlet x = 1\n```")
+    }
+
+    @Test("Uses a longer fence when content contains backtick runs")
+    func usesLongerFenceForBackticks() {
+        let pasted = PastedTextAttachment(text: "```\ncode\n```")
+        let composed = Chat.composeCommand(text: "", pastedTexts: [pasted])
+        #expect(composed == "````\n```\ncode\n```\n````")
+    }
+
+    @Test("Returns trimmed text when there are no pasted attachments")
+    func returnsPlainTextWithoutAttachments() {
+        #expect(Chat.composeCommand(text: "  hello  ", pastedTexts: []) == "hello")
+    }
+}

--- a/VisionOS/ChatView.swift
+++ b/VisionOS/ChatView.swift
@@ -11,10 +11,12 @@ import PhotosUI
 struct ChatView: View {
     @Bindable var chat: Chat
     @State private var inputText = ""
-    @FocusState private var isInputFocused: Bool
     @State private var showConversations = false
     @State private var selectedPhotos: [PhotosPickerItem] = []
     @State private var pendingImages: [ChatImage] = []
+    @State private var pendingPastedTexts: [PastedTextAttachment] = []
+    @State private var previousInputText = ""
+    @State private var expandedPastedText: PastedTextAttachment?
     @State private var showSuggestions = false
 
     private func updateShowSuggestions() {
@@ -27,6 +29,7 @@ struct ChatView: View {
     var body: some View {
         NavigationStack {
             VStack(spacing: 0) {
+                ConversationTabBar(chat: chat)
                 if let error = chat.sessionError {
                     sessionErrorBanner(error)
                 }
@@ -39,6 +42,7 @@ struct ChatView: View {
                     .padding(.vertical, 8)
                 }
                 Divider()
+                pastedTextBar
                 imagePreviewBar
                 inputBar
             }
@@ -86,6 +90,22 @@ struct ChatView: View {
         .onChange(of: selectedPhotos) {
             Task { await loadSelectedPhotos() }
         }
+        .onChange(of: inputText) { _, newValue in handleInputChange(newValue) }
+        .background(tabCycleShortcuts)
+        .sheet(item: $expandedPastedText) { attachment in
+            PastedTextDetailView(attachment: attachment) { expandedPastedText = nil }
+        }
+    }
+
+    private var tabCycleShortcuts: some View {
+        HStack(spacing: 0) {
+            Button(action: { Task { await chat.cycleTab(forward: true) } }, label: { EmptyView() })
+                .keyboardShortcut("]", modifiers: [.command, .shift])
+            Button(action: { Task { await chat.cycleTab(forward: false) } }, label: { EmptyView() })
+                .keyboardShortcut("[", modifiers: [.command, .shift])
+        }
+        .opacity(0)
+        .allowsHitTesting(false)
     }
 
     // MARK: - Messages
@@ -94,8 +114,11 @@ struct ChatView: View {
         Group {
             if let convId = chat.conversationId {
                 ConversationScrollView(convId: convId, chat: chat)
+            } else {
+                Color.clear
             }
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     // MARK: - Image preview
@@ -124,6 +147,30 @@ struct ChatView: View {
                             })
                             .offset(x: 4, y: -4)
                         }
+                    }
+                }
+                .padding(.horizontal)
+                .padding(.vertical, 8)
+            }
+            Divider()
+        }
+    }
+
+    // MARK: - Pasted text preview
+
+    @ViewBuilder
+    private var pastedTextBar: some View {
+        if !pendingPastedTexts.isEmpty {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 8) {
+                    ForEach(pendingPastedTexts) { attachment in
+                        PastedTextChip(
+                            attachment: attachment,
+                            onTap: { expandedPastedText = attachment },
+                            onRemove: {
+                                pendingPastedTexts.removeAll { $0.id == attachment.id }
+                            }
+                        )
                     }
                 }
                 .padding(.horizontal)
@@ -164,14 +211,14 @@ struct ChatView: View {
                     }
                     .disabled(isLoading)
 
-                    TextField("Ask anything…", text: $inputText, axis: .vertical)
-                        .font(Theme.Fonts.bodyLarge)
-                        .textFieldStyle(.plain)
-                        .lineLimit(1...10)
-                        .focused($isInputFocused)
-                        .submitLabel(.send)
-                        .onSubmit { sendMessage() }
-                        .onAppear { isInputFocused = true }
+                    ChatComposerTextField(
+                        text: $inputText,
+                        focusOnAppear: true,
+                        onSubmit: { sendMessage() },
+                        onPasteLargeText: { pending in
+                            pendingPastedTexts.append(PastedTextAttachment(text: pending))
+                        }
+                    )
 
                     Button(action: sendMessage) {
                         Image(systemName: "arrow.up.circle.fill")
@@ -188,7 +235,8 @@ struct ChatView: View {
     private var canSend: Bool {
         let hasText = !inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         let hasImages = !pendingImages.isEmpty
-        return (hasText || hasImages) && !chat.isLoading
+        let hasPasted = !pendingPastedTexts.isEmpty
+        return (hasText || hasImages || hasPasted) && !chat.isLoading
     }
 
     private var recordingOverlay: some View {
@@ -261,10 +309,23 @@ struct ChatView: View {
     private func sendMessage() {
         let text = inputText
         let images = pendingImages
+        let pasted = pendingPastedTexts
         inputText = ""
+        previousInputText = ""
         pendingImages = []
+        pendingPastedTexts = []
         selectedPhotos = []
-        Task { await chat.send(text, images: images) }
+        Task { await chat.send(text, images: images, pastedTexts: pasted) }
+    }
+
+    private func handleInputChange(_ newValue: String) {
+        if let result = PastedTextAttachment.detectLargeInsertion(old: previousInputText, new: newValue) {
+            pendingPastedTexts.append(PastedTextAttachment(text: result.inserted))
+            inputText = result.remaining
+            previousInputText = result.remaining
+        } else {
+            previousInputText = newValue
+        }
     }
 
     private func loadSelectedPhotos() async {

--- a/iOS/ChatView.swift
+++ b/iOS/ChatView.swift
@@ -33,13 +33,15 @@ private func formatRelativeDate(_ isoString: String) -> String {
 struct ChatView: View {
     @Bindable var chat: Chat
     @State private var inputText = ""
-    @FocusState private var isInputFocused: Bool
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @State private var showConversations = false
     @State private var compactNavPath: [String] = []
     @State private var holdRecordStart: Date?
     @State private var selectedPhotos: [PhotosPickerItem] = []
     @State private var pendingImages: [ChatImage] = []
+    @State private var pendingPastedTexts: [PastedTextAttachment] = []
+    @State private var previousInputText = ""
+    @State private var expandedPastedText: PastedTextAttachment?
     @State private var renamingConversation: Conversation?
     @State private var renameText = ""
     @State private var showSuggestions = false
@@ -224,6 +226,7 @@ struct ChatView: View {
 
     private var chatDetail: some View {
         VStack(spacing: 0) {
+            ConversationTabBar(chat: chat)
             if let error = chat.sessionError { sessionErrorBanner(error) }
             chatMessages
             if showSuggestions {
@@ -231,12 +234,29 @@ struct ChatView: View {
                     .padding(.vertical, 8)
             }
             Divider()
+            pastedTextBar
             imagePreviewBar
             inputBar
         }
         .background(Theme.Colors.background)
         .navigationTitle(chat.conversationId != nil ? "Assistant" : "New Chat")
         .navigationBarTitleDisplayMode(.inline)
+        .background(tabCycleShortcuts)
+        .onChange(of: inputText) { _, newValue in handleInputChange(newValue) }
+        .sheet(item: $expandedPastedText) { attachment in
+            PastedTextDetailView(attachment: attachment) { expandedPastedText = nil }
+        }
+    }
+
+    private var tabCycleShortcuts: some View {
+        HStack(spacing: 0) {
+            Button(action: { Task { await chat.cycleTab(forward: true) } }, label: { EmptyView() })
+                .keyboardShortcut("]", modifiers: [.command, .shift])
+            Button(action: { Task { await chat.cycleTab(forward: false) } }, label: { EmptyView() })
+                .keyboardShortcut("[", modifiers: [.command, .shift])
+        }
+        .opacity(0)
+        .allowsHitTesting(false)
     }
 
     private func sessionErrorBanner(_ error: String) -> some View {
@@ -263,7 +283,36 @@ struct ChatView: View {
         Group {
             if let convId = chat.conversationId {
                 ConversationScrollView(convId: convId, chat: chat)
+            } else {
+                Color.clear
             }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+extension ChatView {
+    // MARK: - Pasted text preview
+
+    @ViewBuilder
+    private var pastedTextBar: some View {
+        if !pendingPastedTexts.isEmpty {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 8) {
+                    ForEach(pendingPastedTexts) { attachment in
+                        PastedTextChip(
+                            attachment: attachment,
+                            onTap: { expandedPastedText = attachment },
+                            onRemove: {
+                                pendingPastedTexts.removeAll { $0.id == attachment.id }
+                            }
+                        )
+                    }
+                }
+                .padding(.horizontal)
+                .padding(.vertical, 8)
+            }
+            Divider()
         }
     }
 
@@ -313,13 +362,13 @@ struct ChatView: View {
                     micButton
                     photoPickerButton
 
-                    TextField("Ask anything…", text: $inputText, axis: .vertical)
-                        .font(Theme.Fonts.bodyLarge)
-                        .textFieldStyle(.plain)
-                        .lineLimit(1...10)
-                        .focused($isInputFocused)
-                        .submitLabel(.send)
-                        .onSubmit { sendMessage() }
+                    ChatComposerTextField(
+                        text: $inputText,
+                        onSubmit: { sendMessage() },
+                        onPasteLargeText: { pending in
+                            pendingPastedTexts.append(PastedTextAttachment(text: pending))
+                        }
+                    )
 
                     Button(action: sendMessage) {
                         Image(systemName: "arrow.up.circle.fill")
@@ -338,7 +387,8 @@ struct ChatView: View {
     private var canSend: Bool {
         let hasText = !inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         let hasImages = !pendingImages.isEmpty
-        return (hasText || hasImages) && !chat.isLoading
+        let hasPasted = !pendingPastedTexts.isEmpty
+        return (hasText || hasImages || hasPasted) && !chat.isLoading
     }
 
     private var photoPickerButton: some View {
@@ -443,10 +493,23 @@ struct ChatView: View {
     private func sendMessage() {
         let text = inputText
         let images = pendingImages
+        let pasted = pendingPastedTexts
         inputText = ""
+        previousInputText = ""
         pendingImages = []
+        pendingPastedTexts = []
         selectedPhotos = []
-        Task { await chat.send(text, images: images) }
+        Task { await chat.send(text, images: images, pastedTexts: pasted) }
+    }
+
+    private func handleInputChange(_ newValue: String) {
+        if let result = PastedTextAttachment.detectLargeInsertion(old: previousInputText, new: newValue) {
+            pendingPastedTexts.append(PastedTextAttachment(text: result.inserted))
+            inputText = result.remaining
+            previousInputText = result.remaining
+        } else {
+            previousInputText = newValue
+        }
     }
 
     private func loadSelectedPhotos() async {

--- a/macOS/ChatView.swift
+++ b/macOS/ChatView.swift
@@ -19,9 +19,11 @@ struct ChatView: View {
     var style: ChatViewStyle = .full
     private let initialQuickChatExpanded: Bool
     @State private var inputText = ""
-    @FocusState private var isInputFocused: Bool
     @State private var holdRecordStart: Date?
     @State private var pendingImages: [ChatImage] = []
+    @State private var pendingPastedTexts: [PastedTextAttachment] = []
+    @State private var previousInputText = ""
+    @State private var expandedPastedText: PastedTextAttachment?
     @State private var showFilePicker = false
     @State private var renamingConversation: Conversation?
     @State private var renameText = ""
@@ -289,6 +291,7 @@ extension ChatView {
 
     private var chatDetail: some View {
         VStack(spacing: 0) {
+            conversationTabBar
             if let error = chat.sessionError {
                 sessionErrorBanner(error)
             }
@@ -301,13 +304,108 @@ extension ChatView {
                 .padding(.vertical, 8)
             }
             Divider()
+            pastedTextBar
             imagePreviewBar
             inputBar
+        }
+        .onChange(of: inputText) { _, newValue in handleInputChange(newValue) }
+        .background(tabCycleShortcuts)
+        .sheet(item: $expandedPastedText) { attachment in
+            PastedTextDetailView(attachment: attachment) { expandedPastedText = nil }
         }
         .onDrop(of: ["public.image"], isTargeted: nil) { providers in
             loadDroppedImages(providers)
             return true
         }
+    }
+
+    // MARK: - Conversation tabs
+
+    @ViewBuilder
+    private var conversationTabBar: some View {
+        let tabs = chat.openTabConversations
+        let showNewTab = chat.conversationId == nil
+        if !tabs.isEmpty || showNewTab {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 6) {
+                    ForEach(tabs) { conv in
+                        conversationTabChip(
+                            title: conv.title ?? "Untitled",
+                            isActive: conv.id == chat.conversationId,
+                            onSelect: { Task { await chat.selectTab(conv.id) } },
+                            onClose: { Task { await chat.closeTab(conv.id) } }
+                        )
+                    }
+                    if showNewTab {
+                        conversationTabChip(
+                            title: "New Chat",
+                            isActive: true,
+                            onSelect: {},
+                            onClose: nil
+                        )
+                    }
+                    Button(action: { chat.startNewConversation() }, label: {
+                        Image(systemName: "plus")
+                            .font(Theme.Fonts.caption)
+                    })
+                    .buttonStyle(.borderless)
+                    .help("New Chat Tab")
+                }
+                .padding(.horizontal, 8)
+                .padding(.vertical, 6)
+            }
+            .background(Theme.Colors.secondaryBackground)
+            Divider()
+        }
+    }
+
+    private func conversationTabChip(
+        title: String,
+        isActive: Bool,
+        onSelect: @escaping () -> Void,
+        onClose: (() -> Void)?
+    ) -> some View {
+        HStack(spacing: 6) {
+            Text(title)
+                .font(Theme.Fonts.caption.weight(isActive ? .semibold : .regular))
+                .foregroundColor(isActive ? Theme.Colors.textPrimary : Theme.Colors.textSecondary)
+                .lineLimit(1)
+            if let onClose {
+                Button(action: onClose, label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 8, weight: .bold))
+                        .foregroundColor(Theme.Colors.textSecondary)
+                })
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 5)
+        .frame(maxWidth: 160)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(isActive ? Theme.Colors.accent.opacity(0.15) : Color.clear)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(
+                    isActive ? Theme.Colors.accent.opacity(0.4) : Theme.Colors.textSecondary.opacity(0.2),
+                    lineWidth: 1
+                )
+        )
+        .contentShape(Rectangle())
+        .onTapGesture(perform: onSelect)
+    }
+
+    private var tabCycleShortcuts: some View {
+        HStack(spacing: 0) {
+            Button(action: { Task { await chat.cycleTab(forward: true) } }, label: { EmptyView() })
+                .keyboardShortcut("]", modifiers: [.command, .shift])
+            Button(action: { Task { await chat.cycleTab(forward: false) } }, label: { EmptyView() })
+                .keyboardShortcut("[", modifiers: [.command, .shift])
+        }
+        .opacity(0)
+        .allowsHitTesting(false)
     }
 
     private func sessionErrorBanner(_ error: String) -> some View {
@@ -338,6 +436,28 @@ extension ChatView {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    @ViewBuilder
+    private var pastedTextBar: some View {
+        if !pendingPastedTexts.isEmpty {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 8) {
+                    ForEach(pendingPastedTexts) { attachment in
+                        PastedTextChip(
+                            attachment: attachment,
+                            onTap: { expandedPastedText = attachment },
+                            onRemove: {
+                                pendingPastedTexts.removeAll { $0.id == attachment.id }
+                            }
+                        )
+                    }
+                }
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+            }
+            Divider()
+        }
     }
 
     @ViewBuilder
@@ -399,16 +519,16 @@ extension ChatView {
                         loadFilePickerImages(result)
                     }
 
-                    TextField("Ask anything…", text: $inputText, axis: .vertical)
-                        .font(Theme.Fonts.bodyLarge)
-                        .textFieldStyle(.plain)
-                        .lineLimit(1...10)
-                        .focused($isInputFocused)
-                        .submitLabel(.send)
-                        .onSubmit { sendMessage() }
-                        // Do NOT auto-focus on macOS: activating the NSTextView field
-                        // editor while streaming triggers ViewBridge XPC and can
-                        // contribute to _NSDetectedLayoutRecursion.
+                    // Do NOT auto-focus on macOS: activating the NSTextView field
+                    // editor while streaming triggers ViewBridge XPC and can
+                    // contribute to _NSDetectedLayoutRecursion.
+                    ChatComposerTextField(
+                        text: $inputText,
+                        onSubmit: { sendMessage() },
+                        onPasteLargeText: { pending in
+                            pendingPastedTexts.append(PastedTextAttachment(text: pending))
+                        }
+                    )
 
                     Button(action: sendMessage) {
                         Image(systemName: "arrow.up.circle.fill")
@@ -427,7 +547,8 @@ extension ChatView {
     private var canSend: Bool {
         let hasText = !inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         let hasImages = !pendingImages.isEmpty
-        return (hasText || hasImages) && !chat.isLoading
+        let hasPasted = !pendingPastedTexts.isEmpty
+        return (hasText || hasImages || hasPasted) && !chat.isLoading
     }
 
     private var micButton: some View {
@@ -492,9 +613,22 @@ extension ChatView {
     private func sendMessage() {
         let text = inputText
         let images = pendingImages
+        let pasted = pendingPastedTexts
         inputText = ""
+        previousInputText = ""
         pendingImages = []
-        Task { await chat.send(text, images: images) }
+        pendingPastedTexts = []
+        Task { await chat.send(text, images: images, pastedTexts: pasted) }
+    }
+
+    private func handleInputChange(_ newValue: String) {
+        if let result = PastedTextAttachment.detectLargeInsertion(old: previousInputText, new: newValue) {
+            pendingPastedTexts.append(PastedTextAttachment(text: result.inserted))
+            inputText = result.remaining
+            previousInputText = result.remaining
+        } else {
+            previousInputText = newValue
+        }
     }
 
     private func loadFilePickerImages(_ result: Result<[URL], Error>) {

--- a/macOS/MacApp.swift
+++ b/macOS/MacApp.swift
@@ -167,6 +167,9 @@ final class MacAppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        // Allow the main window group to use native macOS window tabs. New main
+        // windows (opened explicitly) then join the existing window as tabs.
+        NSWindow.allowsAutomaticWindowTabbing = true
         if UserDefaults.standard.string(forKey: quickChatShortcutDefaultsKey) == nil {
             UserDefaults.standard.set(
                 QuickChatShortcut.defaultShortcut.rawValue,
@@ -200,8 +203,13 @@ final class MacAppDelegate: NSObject, NSApplicationDelegate {
         _ sender: NSApplication,
         hasVisibleWindows flag: Bool
     ) -> Bool {
+        let hasExistingWindow = !primaryWindows.isEmpty
         presentMainApp()
-        return true
+        // When a primary window already exists we reuse it and return false so AppKit
+        // does not additionally create/restore an untitled duplicate window (the source
+        // of the occasional duplicate). Only fall back to AppKit's default handling
+        // when there is genuinely no window to restore.
+        return !hasExistingWindow
     }
 
     func requestFullQuit() {
@@ -295,6 +303,7 @@ final class MacAppDelegate: NSObject, NSApplicationDelegate {
 
     private func presentMainApp(section: String? = nil) {
         restoreDockPresence()
+        collapseDuplicatePrimaryWindows()
         restorePrimaryWindows()
         NSApp.activate(ignoringOtherApps: true)
         if let section {
@@ -303,6 +312,22 @@ final class MacAppDelegate: NSObject, NSApplicationDelegate {
                 object: nil,
                 userInfo: ["section": section]
             )
+        }
+    }
+
+    /// Keeps a single primary (main) window alive, closing any accidental duplicates
+    /// created by scene restoration/reopen. Windows that belong to a multi-window tab
+    /// group are user-intended (native window tabs) and are left untouched.
+    private func collapseDuplicatePrimaryWindows() {
+        let windows = primaryWindows.filter { window in
+            (window.tabGroup?.windows.count ?? 1) <= 1
+        }
+        guard windows.count > 1 else { return }
+        let keep = windows.first { $0.isKeyWindow }
+            ?? NSApp.orderedWindows.first(where: { windows.contains($0) })
+            ?? windows[0]
+        for window in windows where window != keep {
+            window.close()
         }
     }
 
@@ -365,9 +390,10 @@ struct MacApp: App {
     @State private var chat = Chat()
     @State private var scooter: Scooter?
     @AppStorage("showMenuBarExtra") private var showMenuBar = true
+    @Environment(\.openWindow) private var openWindow
 
     var body: some Scene {
-        WindowGroup {
+        WindowGroup(id: "main") {
             mainContent
                 .onAppear {
                     appDelegate.configure(sharedChat: chat)
@@ -403,6 +429,11 @@ struct MacApp: App {
                     )
                 }
                 .keyboardShortcut("n", modifiers: .command)
+
+                Button("New Window") {
+                    openWindow(id: "main")
+                }
+                .keyboardShortcut("n", modifiers: [.command, .shift])
             }
 
             CommandMenu("Navigate") {


### PR DESCRIPTION
## Summary

Improves the AI chat experience across macOS, iOS, and VisionOS.

### Large paste handling (ChatGPT/Claude style)
- Adds a shared `ChatComposerTextField` (UIKit `UITextView` / AppKit `NSTextView` representable) that **intercepts the paste event itself**. When clipboard content is large (≥600 chars or ≥15 lines), it never enters the editor — it becomes a `PastedTextAttachment` chip instead and is composed into the outgoing message as a fenced code block on send.
- Fixes the previous hang on large pastes: the huge string is never placed in the text view, so there's no giant re-layout.
- Small pastes and normal typing are unchanged.

### New-chat positioning
- Ports the macOS new-chat positioning fix (#189) to iOS and VisionOS.

### Conversation tabs (stretch goal)
- Adds in-app conversation tabs plus native macOS window tabbing, including Quick Chat, with keyboard cycling.

### macOS window management
- Reuses the existing main window instead of spawning duplicates; a new window opens only on explicit request (⌘⇧N).

### Version
- Patch bump to 1.8.14.

## Testing
- SwiftLint `--strict`: 0 violations
- Builds succeed on macOS, iOS, and VisionOS
- Unit tests pass (`PastedTextAttachmentTests`, `ChatComposeCommandTests`, `ChatTranscriptRendererTests`)