### PR TITLE
fix: present main macOS window at launch

### DIFF
--- a/macOS/MacApp.swift
+++ b/macOS/MacApp.swift
@@ -420,6 +420,7 @@ struct MacApp: App {
                 }
         }
         .defaultSize(width: 900, height: 700)
+        .defaultLaunchBehavior(.presented)
         .commands {
             CommandGroup(replacing: .newItem) {
                 Button("New Conversation") {


### PR DESCRIPTION
## Problem

After #195 the app sometimes opens with no main window on macOS — only the menu-bar item appears when you first open the app.

## Cause

#195 gave the primary `WindowGroup` an explicit `id: "main"` (needed so the new **⇧⌘N New Window** command could call `openWindow(id: "main")`). On macOS, once a `WindowGroup` has an explicit id and sits alongside the `MenuBarExtra`, SwiftUI's window restoration no longer reliably presents it at cold launch.

## Fix

Add `.defaultLaunchBehavior(.presented)` to the main `WindowGroup` so SwiftUI presents it on launch, while keeping the `id: "main"` (and the New Window / window-reuse / tabbing behaviour from #195) intact.

## Validation

- macOS target builds successfully.
- `swiftlint --strict` passes.