### PR TITLE
feat: metrics dashboard, air purifier appliance, and animated icons

### DIFF
--- a/FluxHaus.xcodeproj/project.pbxproj
+++ b/FluxHaus.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		0346F947F8AB67D4BD3DB774 /* WeatherView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636B9B39258E57D400DE97BD /* WeatherView.swift */; };
 		0519DE362C5E9763003F3796 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1287B4482C5E9763003F3796 /* Theme.swift */; };
 		057460FC18168E1CE9B3C520 /* RobotIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = E38B4A64D5666D588E647CA0 /* RobotIntents.swift */; };
+		0A9DBF07ABD0167C4A70A498 /* AirPurifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D19F8EEA5798CC3C15E2B3E7 /* AirPurifier.swift */; };
+		C326B080083CA782012B624F /* SymbolAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A96158EDADA7F5C537A798F6 /* SymbolAnimation.swift */; };
 		0AC5EE3121562133680D3C3C /* RobotIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = E38B4A64D5666D588E647CA0 /* RobotIntents.swift */; };
 		0B1E0128C093516D2338D7B8 /* Weather.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636B9B44258E5C3600DE97BD /* Weather.swift */; };
 		0CC21D2502790A21385B0E63 /* FluxIntentActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9D32097FA44F78B3A97A743 /* FluxIntentActions.swift */; };
@@ -25,9 +27,12 @@
 		16E5F0715B8C44C3462F4FA5 /* CarPlayVoiceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7F4D12AFB5260CA5BD9CE33 /* CarPlayVoiceManager.swift */; };
 		1B172CC6F51E41DD0346F2C7 /* MockDataUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BC999E976448F6757BA7155 /* MockDataUITests.swift */; };
 		1D0580D31B64ED384590793B /* AppliancesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 632CBC7D25870CBB003E4988 /* AppliancesView.swift */; };
+		1D3DB0F80B73727DC42CA95F /* Metrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2888C94C0601F4FE3B8598E0 /* Metrics.swift */; };
 		1EE958BBEBFBE734319E4BAB /* SystemNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6399EA2B2B9D2CCF000C8CA4 /* SystemNotifications.swift */; };
 		208C0E652C5E9763003F3796 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1287B4482C5E9763003F3796 /* Theme.swift */; };
 		20B3C50781AECEC9A50DCD5D /* BackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636B9B4F258E912A00DE97BD /* BackgroundView.swift */; };
+		20EC81A3A000AC07341A686F /* MetricsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDA1299FF4CBBF0A30638E78 /* MetricsView.swift */; };
+		21B330CE9408AA1578972F0F /* MetricsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDA1299FF4CBBF0A30638E78 /* MetricsView.swift */; };
 		225311E8D0A34FE1A853BFA7 /* RobotsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023E1C2F41844A628251CE04 /* RobotsListView.swift */; };
 		233E302E4A3E42AEA96D94E2 /* Scooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF67D2F97BC4B6C8737FCC9 /* Scooter.swift */; };
 		256B98E625030109C7B0072B /* FluxHausConsts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 632CBC7625870B74003E4988 /* FluxHausConsts.swift */; };
@@ -41,6 +46,7 @@
 		2E1D40C98BE0FF4DC9908011 /* CarIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45C4E146327FD1D9CBFE6A47 /* CarIntents.swift */; };
 		2F0F61B01E0417876339D892 /* AskFluxHausIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 782942CD000CCCFFE0D7C43F /* AskFluxHausIntent.swift */; };
 		31FCD81922AE005906F0AC46 /* WeatherHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAAEBC8C9F79B50F67076AB6 /* WeatherHelpers.swift */; };
+		322919E39C024D5394F91AAB /* AirPurifierView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EE43EF7F3A9147830DC77B9 /* AirPurifierView.swift */; };
 		323C8C60BEA480D9040C3B37 /* RobotDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 637CE4C42BE71FC000258158 /* RobotDetailView.swift */; };
 		356CABB63DDB3E4A42EBEBEB /* FluxHausShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D432F22FDA43AC78A33FFF /* FluxHausShortcuts.swift */; };
 		36CDAE36186F337CA02795D9 /* HomeConnect.swift in Sources */ = {isa = PBXBuildFile; fileRef = 632CBC8F2587B4AD003E4988 /* HomeConnect.swift */; };
@@ -53,7 +59,11 @@
 		3861C20261D19FA4398114C0 /* QueryFlux.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6399EA352B9D7901000C8CA4 /* QueryFlux.swift */; };
 		3CFA1F5604BA445D83EE6D88 /* ScooterDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8CB990FC6404C8682E3BE62 /* ScooterDetailView.swift */; };
 		3F181EC009E59832882455EA /* WeatherHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAAEBC8C9F79B50F67076AB6 /* WeatherHelpers.swift */; };
+		40B023B629D97801E4222B9B /* AirPurifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D19F8EEA5798CC3C15E2B3E7 /* AirPurifier.swift */; };
+		F5E45585943A8816A131812F /* SymbolAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A96158EDADA7F5C537A798F6 /* SymbolAnimation.swift */; };
+		40EEA00C50058903160511F5 /* Metrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2888C94C0601F4FE3B8598E0 /* Metrics.swift */; };
 		42E9D45E3DEE4ED4BF3EBB9C /* ScooterDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8CB990FC6404C8682E3BE62 /* ScooterDetailView.swift */; };
+		43D36BFDE9C894B41DC54FFC /* Metrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2888C94C0601F4FE3B8598E0 /* Metrics.swift */; };
 		44AB10F051A0C91C563B0EE4 /* FluxIntentActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9D32097FA44F78B3A97A743 /* FluxIntentActions.swift */; };
 		47DAD3A56DB24CE1A601DE56 /* DateTimeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 632CBC25258682C8003E4988 /* DateTimeView.swift */; };
 		49CC496DED762D35041AA043 /* CarIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45C4E146327FD1D9CBFE6A47 /* CarIntents.swift */; };
@@ -63,11 +73,15 @@
 		4EE7C07CB284872F0B2165AB /* CarHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 633F09472BBB8F8F0052C088 /* CarHelper.swift */; };
 		4FD86E14AA62A32A6FF600A8 /* CarIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45C4E146327FD1D9CBFE6A47 /* CarIntents.swift */; };
 		55FD5BBD882FC925D75E3214 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1287B4482C5E9763003F3796 /* Theme.swift */; };
+		56476772DC1C3CC92BB58030 /* MetricsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDA1299FF4CBBF0A30638E78 /* MetricsView.swift */; };
 		58489E7EBF8C80A6A3DFF2AD /* Battery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636A05982B9E6EE800D42C0D /* Battery.swift */; };
 		5A5D2CC899AC78FE86363152 /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 726CDAE4D264490999414676 /* AuthManager.swift */; };
+		5B438D8B41E74BCE6BC2C17F /* AirPurifierView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EE43EF7F3A9147830DC77B9 /* AirPurifierView.swift */; };
 		5B735B126D86700D42C36453 /* WeatherAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6369A138259984E400888E5D /* WeatherAlertView.swift */; };
 		5B774F20138F2ACFB6594502 /* WhereWeAre.swift in Sources */ = {isa = PBXBuildFile; fileRef = 635BD66F2B9DFAE1009CEEA9 /* WhereWeAre.swift */; };
 		5C3861FC78328082D3079690 /* SceneService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B21E737133023F1FB8033FE1 /* SceneService.swift */; };
+		5C618A9BA6758D568FE9988A /* AirPurifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D19F8EEA5798CC3C15E2B3E7 /* AirPurifier.swift */; };
+		C20BCB435D427473214CC26D /* SymbolAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A96158EDADA7F5C537A798F6 /* SymbolAnimation.swift */; };
 		5D05B5523942BB577B0175D4 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2A45F8EEDC9709FC705CE7 /* LoginView.swift */; };
 		5D4730DE346F4F3096732C83 /* RobotsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023E1C2F41844A628251CE04 /* RobotsListView.swift */; };
 		5E7EE46FF4B2D86974A97228 /* AppliancesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 632CBC7D25870CBB003E4988 /* AppliancesView.swift */; };
@@ -182,14 +196,17 @@
 		65AC26A6D238F5635F082B02 /* RobotIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = E38B4A64D5666D588E647CA0 /* RobotIntents.swift */; };
 		66106D4DFC5F30C42C88F574 /* MenuBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76553EE6B9F944EC9FC27BB7 /* MenuBarView.swift */; };
 		6761CEA937D36001BDB9337C /* SceneIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = A99B53B9664ECD2C6F981E9D /* SceneIntents.swift */; };
+		6ADE9F9431C75D52982CF9F7 /* MetricsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDA1299FF4CBBF0A30638E78 /* MetricsView.swift */; };
 		6C718CFE95C3BC769046E180 /* CarIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45C4E146327FD1D9CBFE6A47 /* CarIntents.swift */; };
 		6D3A6DF0ADB0547372080998 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 632CBC26258682C9003E4988 /* Assets.xcassets */; };
 		6FCFCDBD5CD529EC139A4A95 /* ApplianceViewHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63610D2D2BB883DA0048B9FF /* ApplianceViewHelpers.swift */; };
+		717D4AF7931630A9E88AE624 /* Metrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2888C94C0601F4FE3B8598E0 /* Metrics.swift */; };
 		76BEC2C027094075424FAC66 /* SceneIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = A99B53B9664ECD2C6F981E9D /* SceneIntents.swift */; };
 		76FDEBDB0F31F8539E4A8B91 /* SceneService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B21E737133023F1FB8033FE1 /* SceneService.swift */; };
 		773F6A161767F7B9301A70C8 /* LoginStucts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63A159272C5E9763003F3796 /* LoginStucts.swift */; };
 		77CDDA9FA1A142A79B3AEB86 /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 726CDAE4D264490999414676 /* AuthManager.swift */; };
 		77FD37A48518D9CC2AF19BFA /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 726CDAE4D264490999414676 /* AuthManager.swift */; };
+		78F7ECC733E1ED102D2A6036 /* AirPurifierView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EE43EF7F3A9147830DC77B9 /* AirPurifierView.swift */; };
 		792A9034DF4408D90BF13274 /* LoginStucts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63A159272C5E9763003F3796 /* LoginStucts.swift */; };
 		7C912107F52EFE69ABBD2EC9 /* FluxHausShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D432F22FDA43AC78A33FFF /* FluxHausShortcuts.swift */; };
 		84C5DCC07BF2CE1E4D72F885 /* WhereWeAre.swift in Sources */ = {isa = PBXBuildFile; fileRef = 635BD66F2B9DFAE1009CEEA9 /* WhereWeAre.swift */; };
@@ -198,6 +215,7 @@
 		8716D5FE3271F7DBCEF8D744 /* ChatService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001000000000000000001 /* ChatService.swift */; };
 		88A694EA13C5590830184818 /* CarDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63610D322BB8864F0048B9FF /* CarDetailView.swift */; };
 		8D80E6BB0FEBF2D6F21674BD /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AC70F639352E9D9252F77D43 /* Cocoa.framework */; };
+		8D9A67B09C25FE371B9809FA /* MetricsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDA1299FF4CBBF0A30638E78 /* MetricsView.swift */; };
 		914CBFB490B76988B7373B05 /* AskFluxHausIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 782942CD000CCCFFE0D7C43F /* AskFluxHausIntent.swift */; };
 		92895C4DCFEB63889AE653C5 /* Car.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63610D282BB86F230048B9FF /* Car.swift */; };
 		92BB68B7C6E3ED9215465CAB /* DateTimeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 632CBC25258682C8003E4988 /* DateTimeView.swift */; };
@@ -209,6 +227,7 @@
 		A08741F491FBACE4244D359F /* AskFluxHausIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 782942CD000CCCFFE0D7C43F /* AskFluxHausIntent.swift */; };
 		A0ED8B507C7C96F517EF4525 /* SceneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6709013ABF8AA633E63B128 /* SceneView.swift */; };
 		A1319CBC6B75067B33D60A3B /* BackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636B9B4F258E912A00DE97BD /* BackgroundView.swift */; };
+		A193C3A71C8305DB25AF9904 /* Metrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2888C94C0601F4FE3B8598E0 /* Metrics.swift */; };
 		A7EB26F31FDF9BA1C1907FEE /* Robots.swift in Sources */ = {isa = PBXBuildFile; fileRef = 635BD66A2B9DF8A6009CEEA9 /* Robots.swift */; };
 		A833D279DDED4F415801541F /* SceneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6709013ABF8AA633E63B128 /* SceneView.swift */; };
 		A8FDEEF5BAC3453BB825E1DF /* ScooterDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8CB990FC6404C8682E3BE62 /* ScooterDetailView.swift */; };
@@ -232,6 +251,7 @@
 		BA938AC82C5E9763003F3796 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1287B4482C5E9763003F3796 /* Theme.swift */; };
 		BAC011F1870F66549C4C6D4E /* FluxHausShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D432F22FDA43AC78A33FFF /* FluxHausShortcuts.swift */; };
 		BD30D0FA8BD289D1AB96975A /* SceneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6709013ABF8AA633E63B128 /* SceneView.swift */; };
+		BDD3FF5256362CE98F8141F0 /* AirPurifierView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EE43EF7F3A9147830DC77B9 /* AirPurifierView.swift */; };
 		BE52C047E38648D2BBCF9F89 /* Scooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF67D2F97BC4B6C8737FCC9 /* Scooter.swift */; };
 		BEA67E939CA04EFAA36CEACF /* Scooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF67D2F97BC4B6C8737FCC9 /* Scooter.swift */; };
 		C26CB6CAACD7386DAA031965 /* Robots.swift in Sources */ = {isa = PBXBuildFile; fileRef = 635BD66A2B9DF8A6009CEEA9 /* Robots.swift */; };
@@ -240,6 +260,8 @@
 		C4441A6919614E6E833113C0 /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 726CDAE4D264490999414676 /* AuthManager.swift */; };
 		C5CEC5CCBE620D65D2B1C9BC /* Login.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6399EA302B9D3671000C8CA4 /* Login.swift */; };
 		C623C52748905A66CF3956EB /* MenuBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76553EE6B9F944EC9FC27BB7 /* MenuBarView.swift */; };
+		CAEFE947A078AF67A541DD37 /* AirPurifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D19F8EEA5798CC3C15E2B3E7 /* AirPurifier.swift */; };
+		A27C5B7B1719C93BEFA5708C /* SymbolAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A96158EDADA7F5C537A798F6 /* SymbolAnimation.swift */; };
 		CB0002000000000000000001 /* ChatBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0001000000000000000001 /* ChatBubble.swift */; };
 		CB0002000000000000000002 /* ChatBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0001000000000000000001 /* ChatBubble.swift */; };
 		CB0002000000000000000003 /* ChatBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0001000000000000000001 /* ChatBubble.swift */; };
@@ -272,6 +294,7 @@
 		D54EA55F6764EF8E1469FF21 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8757ED2EF3E226D6B1548CAE /* SettingsView.swift */; };
 		D8A5836912F3F1DF56628A1C /* QueryFlux.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6399EA352B9D7901000C8CA4 /* QueryFlux.swift */; };
 		D8D21373FC74A18689317FBB /* RobotDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 637CE4C42BE71FC000258158 /* RobotDetailView.swift */; };
+		D8DFFD9156EFE9C0279611C5 /* AirPurifierView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EE43EF7F3A9147830DC77B9 /* AirPurifierView.swift */; };
 		D97C56BE82C2647B9CAD0455 /* CarPlay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AD54CBBAC6C6B09392534272 /* CarPlay.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		DA526145341C4A909E252425 /* FluxWidgetWatchViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0398A1FEEF114AC2BF749CE3 /* FluxWidgetWatchViews.swift */; };
 		DB270713ED62FAF0BB0921F5 /* HomeKitView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636B9B5A258FBB6300DE97BD /* HomeKitView.swift */; };
@@ -295,6 +318,8 @@
 		F27145294822FFB5FE80E84F /* ChatService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001000000000000000001 /* ChatService.swift */; };
 		F3C3D67FDFFEFDA41639835B /* RobotIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = E38B4A64D5666D588E647CA0 /* RobotIntents.swift */; };
 		F57287FA1413E1215F02B546 /* LiveActivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E1EE68A8DCE61464036EA06 /* LiveActivityManager.swift */; };
+		F595397493CD5FCACB96AE7B /* AirPurifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D19F8EEA5798CC3C15E2B3E7 /* AirPurifier.swift */; };
+		9B78596D56FBBFD6111E1D9B /* SymbolAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A96158EDADA7F5C537A798F6 /* SymbolAnimation.swift */; };
 		FBA9A54858486FCD8D6AD240 /* Weather.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636B9B44258E5C3600DE97BD /* Weather.swift */; };
 		FC70519504B244809D095CEC /* ScooterDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8CB990FC6404C8682E3BE62 /* ScooterDetailView.swift */; };
 		FD5BDD26916198636BEBC72A /* CarDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63610D322BB8864F0048B9FF /* CarDetailView.swift */; };
@@ -385,6 +410,7 @@
 		1287B4482C5E9763003F3796 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		1B9B78F7F035E29316F494F7 /* ChatView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ChatView.swift; sourceTree = "<group>"; };
 		1C755D2CAD40D63EDE9D51C7 /* CarPlaySceneDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CarPlaySceneDelegate.swift; sourceTree = "<group>"; };
+		2888C94C0601F4FE3B8598E0 /* Metrics.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Metrics.swift; sourceTree = "<group>"; };
 		2B56D970AFBA3A10835EE7D9 /* StatusIntents.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StatusIntents.swift; sourceTree = "<group>"; };
 		35E37BE77DA97D1A7B4F3394 /* ContentView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		37D0A0000000000000000001 /* SuggestionChips.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionChips.swift; sourceTree = "<group>"; };
@@ -474,6 +500,7 @@
 		76553EE6B9F944EC9FC27BB7 /* MenuBarView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MenuBarView.swift; sourceTree = "<group>"; };
 		77A49425BDF4F7DDFA1EE83F /* Tests_macOS_SwiftTesting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_macOS_SwiftTesting.swift; sourceTree = "<group>"; };
 		782942CD000CCCFFE0D7C43F /* AskFluxHausIntent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AskFluxHausIntent.swift; sourceTree = "<group>"; };
+		7EE43EF7F3A9147830DC77B9 /* AirPurifierView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AirPurifierView.swift; sourceTree = "<group>"; };
 		8757ED2EF3E226D6B1548CAE /* SettingsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		9E1EE68A8DCE61464036EA06 /* LiveActivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityManager.swift; sourceTree = "<group>"; };
 		A014C8FED1F0DB5B5127FCB1 /* Tests macOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Tests macOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -500,8 +527,11 @@
 		CTR0001000000000000000004 /* ChatTranscriptRenderer.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = ChatTranscriptRenderer.js; sourceTree = "<group>"; };
 		CTR0005000000000000000002 /* ChatTranscriptRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTranscriptRendererTests.swift; sourceTree = "<group>"; };
 		CWV0001000000000000000001 /* ConversationWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationWebView.swift; sourceTree = "<group>"; };
+		D19F8EEA5798CC3C15E2B3E7 /* AirPurifier.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AirPurifier.swift; sourceTree = "<group>"; };
+		A96158EDADA7F5C537A798F6 /* SymbolAnimation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SymbolAnimation.swift; sourceTree = "<group>"; };
 		D7F4D12AFB5260CA5BD9CE33 /* CarPlayVoiceManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CarPlayVoiceManager.swift; sourceTree = "<group>"; };
 		E38B4A64D5666D588E647CA0 /* RobotIntents.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RobotIntents.swift; sourceTree = "<group>"; };
+		EDA1299FF4CBBF0A30638E78 /* MetricsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MetricsView.swift; sourceTree = "<group>"; };
 		F9D32097FA44F78B3A97A743 /* FluxIntentActions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FluxIntentActions.swift; sourceTree = "<group>"; };
 		FAAEBC8C9F79B50F67076AB6 /* WeatherHelpers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WeatherHelpers.swift; sourceTree = "<group>"; };
 		MD0001000000000000000001 /* MarkdownContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownContentView.swift; sourceTree = "<group>"; };
@@ -672,6 +702,11 @@
 				MP0001000000000000000001 /* MarkdownParser.swift */,
 				NS0001000000000000000001 /* NotificationSettingsView.swift */,
 				08BB574423DB63460BD22B44 /* Intents */,
+				D19F8EEA5798CC3C15E2B3E7 /* AirPurifier.swift */,
+				A96158EDADA7F5C537A798F6 /* SymbolAnimation.swift */,
+				7EE43EF7F3A9147830DC77B9 /* AirPurifierView.swift */,
+				2888C94C0601F4FE3B8598E0 /* Metrics.swift */,
+				EDA1299FF4CBBF0A30638E78 /* MetricsView.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -1218,6 +1253,11 @@
 				5E7F9732F0E2D22130D6E339 /* StatusIntents.swift in Sources */,
 				A08741F491FBACE4244D359F /* AskFluxHausIntent.swift in Sources */,
 				BAC011F1870F66549C4C6D4E /* FluxHausShortcuts.swift in Sources */,
+				CAEFE947A078AF67A541DD37 /* AirPurifier.swift in Sources */,
+				A27C5B7B1719C93BEFA5708C /* SymbolAnimation.swift in Sources */,
+				5B438D8B41E74BCE6BC2C17F /* AirPurifierView.swift in Sources */,
+				A193C3A71C8305DB25AF9904 /* Metrics.swift in Sources */,
+				21B330CE9408AA1578972F0F /* MetricsView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1292,6 +1332,11 @@
 				863F05984934657C4DFF4C77 /* StatusIntents.swift in Sources */,
 				2F0F61B01E0417876339D892 /* AskFluxHausIntent.swift in Sources */,
 				7C912107F52EFE69ABBD2EC9 /* FluxHausShortcuts.swift in Sources */,
+				0A9DBF07ABD0167C4A70A498 /* AirPurifier.swift in Sources */,
+				C326B080083CA782012B624F /* SymbolAnimation.swift in Sources */,
+				322919E39C024D5394F91AAB /* AirPurifierView.swift in Sources */,
+				717D4AF7931630A9E88AE624 /* Metrics.swift in Sources */,
+				20EC81A3A000AC07341A686F /* MetricsView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1338,6 +1383,11 @@
 				0CC21D2502790A21385B0E63 /* FluxIntentActions.swift in Sources */,
 				F3C3D67FDFFEFDA41639835B /* RobotIntents.swift in Sources */,
 				4FD86E14AA62A32A6FF600A8 /* CarIntents.swift in Sources */,
+				F595397493CD5FCACB96AE7B /* AirPurifier.swift in Sources */,
+				9B78596D56FBBFD6111E1D9B /* SymbolAnimation.swift in Sources */,
+				78F7ECC733E1ED102D2A6036 /* AirPurifierView.swift in Sources */,
+				40EEA00C50058903160511F5 /* Metrics.swift in Sources */,
+				56476772DC1C3CC92BB58030 /* MetricsView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1407,6 +1457,11 @@
 				E8F51AC7B9126DD96390720E /* StatusIntents.swift in Sources */,
 				C407064D75A040943618FCF3 /* AskFluxHausIntent.swift in Sources */,
 				356CABB63DDB3E4A42EBEBEB /* FluxHausShortcuts.swift in Sources */,
+				5C618A9BA6758D568FE9988A /* AirPurifier.swift in Sources */,
+				C20BCB435D427473214CC26D /* SymbolAnimation.swift in Sources */,
+				D8DFFD9156EFE9C0279611C5 /* AirPurifierView.swift in Sources */,
+				1D3DB0F80B73727DC42CA95F /* Metrics.swift in Sources */,
+				8D9A67B09C25FE371B9809FA /* MetricsView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1499,6 +1554,11 @@
 				2B436CB5F8250F69DF304824 /* StatusIntents.swift in Sources */,
 				914CBFB490B76988B7373B05 /* AskFluxHausIntent.swift in Sources */,
 				EB186FDC19BACF05F5B9FA83 /* FluxHausShortcuts.swift in Sources */,
+				40B023B629D97801E4222B9B /* AirPurifier.swift in Sources */,
+				F5E45585943A8816A131812F /* SymbolAnimation.swift in Sources */,
+				BDD3FF5256362CE98F8141F0 /* AirPurifierView.swift in Sources */,
+				43D36BFDE9C894B41DC54FFC /* Metrics.swift in Sources */,
+				6ADE9F9431C75D52982CF9F7 /* MetricsView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/FluxWidget/FluxWidget.swift
+++ b/FluxWidget/FluxWidget.swift
@@ -88,7 +88,7 @@ struct Provider: AppIntentTimelineProvider {
         WidgetDevice(
             name: "BroomBot",
             progress: 85,
-            icon: "fan",
+            icon: "robotic.vacuum",
             trailingText: "85%",
             shortText: "On",
             running: true
@@ -417,7 +417,7 @@ let staticList = [
     WidgetDevice(
         name: "BroomBot",
         progress: 85,
-        icon: "fan",
+        icon: "robotic.vacuum",
         trailingText: "85%",
         shortText: "Off",
         running: true

--- a/FluxWidget/FluxWidgetLiveActivity.swift
+++ b/FluxWidget/FluxWidgetLiveActivity.swift
@@ -431,7 +431,7 @@ extension FluxWidgetMultiAttributes.ContentState {
                 running: true, programName: "Cotton"
             ),
             WidgetDevice(
-                name: "BroomBot", progress: 75, icon: "fan",
+                name: "BroomBot", progress: 75, icon: "robotic.vacuum",
                 trailingText: "Cleaning", shortText: "Cleaning",
                 running: true, battery: 75
             )

--- a/Shared/AirPurifier.swift
+++ b/Shared/AirPurifier.swift
@@ -1,0 +1,141 @@
+//
+//  AirPurifier.swift
+//  FluxHaus
+//
+//  Blue Pure air purifier control and status.
+//
+
+import Foundation
+import os
+
+private let logger = Logger(subsystem: "io.fluxhaus.FluxHaus", category: "AirPurifier")
+
+public struct AirPurifierState: Codable {
+    public let timestamp: String?
+    public let online: Bool
+    public let fanOn: Bool
+    public let fanSpeed: Int?
+    public let presetMode: String?
+    public let presetModes: [String]
+    public let lightOn: Bool
+    public let brightness: Int?
+    public let pm25: Double?
+    public let filterLife: Double?
+
+    public init(
+        timestamp: String? = nil,
+        online: Bool = false,
+        fanOn: Bool = false,
+        fanSpeed: Int? = nil,
+        presetMode: String? = nil,
+        presetModes: [String] = [],
+        lightOn: Bool = false,
+        brightness: Int? = nil,
+        pm25: Double? = nil,
+        filterLife: Double? = nil
+    ) {
+        self.timestamp = timestamp
+        self.online = online
+        self.fanOn = fanOn
+        self.fanSpeed = fanSpeed
+        self.presetMode = presetMode
+        self.presetModes = presetModes
+        self.lightOn = lightOn
+        self.brightness = brightness
+        self.pm25 = pm25
+        self.filterLife = filterLife
+    }
+}
+
+@MainActor
+@Observable class AirPurifier {
+    var apiResponse: Api?
+    var status = AirPurifierState()
+
+    func setApiResponse(apiResponse: Api) {
+        self.apiResponse = apiResponse
+        fetchDetails()
+    }
+
+    func fetchDetails() {
+        if let purifier = apiResponse?.response?.airPurifier {
+            status = purifier
+        }
+    }
+
+    var isAuto: Bool { status.presetMode == "auto" }
+    var isNight: Bool { status.presetMode == "night" }
+
+    var formattedPm25: String {
+        guard let pm25 = status.pm25 else { return "—" }
+        return String(format: "%.0f µg/m³", pm25)
+    }
+
+    var formattedFilterLife: String {
+        guard let filter = status.filterLife else { return "—" }
+        return String(format: "%.0f%%", filter)
+    }
+
+    var brightnessPercent: Double {
+        guard let brightness = status.brightness else { return 0 }
+        return (Double(brightness) / 255.0) * 100.0
+    }
+
+    // MARK: - Actions
+
+    func setFan(on isOn: Bool) {
+        performAction(path: "/airPurifierFan", body: ["on": isOn])
+    }
+
+    func setSpeed(percentage: Int) {
+        performAction(path: "/airPurifierSpeed", body: ["percentage": percentage])
+    }
+
+    func setPreset(mode: String) {
+        performAction(path: "/airPurifierPreset", body: ["mode": mode])
+    }
+
+    func setLight(on isOn: Bool) {
+        performAction(path: "/airPurifierLight", body: ["on": isOn])
+    }
+
+    func setBrightness(percentage: Int) {
+        performAction(path: "/airPurifierLight", body: ["brightness": percentage])
+    }
+
+    private func performAction(path: String, body: [String: Any]) {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = "api.fluxhaus.io"
+        components.path = path
+        guard let url = components.url else { return }
+
+        Task {
+            let csrfToken = await fetchCsrfToken()
+
+            var request = URLRequest(url: url)
+            request.httpMethod = "POST"
+            request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.addValue("application/json", forHTTPHeaderField: "Accept")
+            if let authHeader = AuthManager.shared.authorizationHeader() {
+                request.setValue(authHeader, forHTTPHeaderField: "Authorization")
+            }
+            if let csrfToken = csrfToken {
+                request.setValue(csrfToken, forHTTPHeaderField: "X-CSRF-Token")
+            }
+            request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+
+            do {
+                let session = URLSession(configuration: .default)
+                let (_, response) = try await session.data(for: request)
+                let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+                logger.info("Air purifier action \(path) completed with HTTP \(statusCode)")
+                if (200...299).contains(statusCode) {
+                    queryFlux(password: WhereWeAre.getPassword() ?? "")
+                }
+            } catch {
+                logger.error("Air purifier action \(path) failed: \(error.localizedDescription)")
+            }
+        }
+    }
+}

--- a/Shared/AirPurifierView.swift
+++ b/Shared/AirPurifierView.swift
@@ -1,0 +1,169 @@
+//
+//  AirPurifierView.swift
+//  FluxHaus
+//
+//  Blue Pure air purifier controls.
+//
+
+import SwiftUI
+
+struct AirPurifierView: View {
+    @Bindable var purifier: AirPurifier
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            header
+            fanControls
+            presetControls
+            lightControls
+            filterFooter
+        }
+        .padding()
+        .background(Theme.Colors.secondaryBackground)
+        .cornerRadius(12)
+    }
+
+    private var header: some View {
+        HStack {
+            Image(systemName: "air.purifier.fill")
+                .font(Theme.Fonts.headerLarge())
+                .foregroundColor(Theme.Colors.accent)
+            VStack(alignment: .leading) {
+                Text("Air Purifier")
+                    .font(Theme.Fonts.headerLarge())
+                    .foregroundColor(Theme.Colors.textPrimary)
+                Text(purifier.status.online ? "Online" : "Offline")
+                    .font(Theme.Fonts.bodySmall)
+                    .foregroundColor(purifier.status.online ? Theme.Colors.success : Theme.Colors.textSecondary)
+            }
+            Spacer()
+            VStack(alignment: .trailing) {
+                Text(purifier.formattedPm25)
+                    .font(Theme.Fonts.bodyLarge)
+                    .foregroundColor(Theme.Colors.textPrimary)
+                Text("PM2.5")
+                    .font(Theme.Fonts.caption)
+                    .foregroundColor(Theme.Colors.textSecondary)
+            }
+        }
+    }
+
+    private var fanControls: some View {
+        Toggle(isOn: Binding(
+            get: { purifier.status.fanOn },
+            set: { purifier.setFan(on: $0) }
+        )) {
+            Label("Fan", systemImage: "fan.fill")
+                .font(Theme.Fonts.bodyMedium)
+                .foregroundColor(Theme.Colors.textPrimary)
+        }
+        .tint(Theme.Colors.accent)
+    }
+
+    private var presetControls: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Mode")
+                .font(Theme.Fonts.bodySmall)
+                .foregroundColor(Theme.Colors.textSecondary)
+            HStack {
+                ForEach(presetOptions, id: \.self) { mode in
+                    Button {
+                        purifier.setPreset(mode: mode)
+                    } label: {
+                        Text(mode.capitalized)
+                            .font(Theme.Fonts.bodyMedium)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 8)
+                            .background(
+                                purifier.status.presetMode == mode
+                                    ? Theme.Colors.accent
+                                    : Theme.Colors.background
+                            )
+                            .foregroundColor(
+                                purifier.status.presetMode == mode
+                                    ? Theme.Colors.background
+                                    : Theme.Colors.textPrimary
+                            )
+                            .cornerRadius(8)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+    }
+
+    private var lightControls: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Toggle(isOn: Binding(
+                get: { purifier.status.lightOn },
+                set: { purifier.setLight(on: $0) }
+            )) {
+                Label("LED Light", systemImage: "lightbulb.fill")
+                    .font(Theme.Fonts.bodyMedium)
+                    .foregroundColor(Theme.Colors.textPrimary)
+            }
+            .tint(Theme.Colors.accent)
+        }
+    }
+
+    private var filterFooter: some View {
+        HStack {
+            Image(systemName: "line.3.horizontal.decrease.circle")
+                .foregroundColor(Theme.Colors.textSecondary)
+            Text("Filter life")
+                .font(Theme.Fonts.bodySmall)
+                .foregroundColor(Theme.Colors.textSecondary)
+            Spacer()
+            Text(purifier.formattedFilterLife)
+                .font(Theme.Fonts.bodySmall)
+                .foregroundColor(Theme.Colors.textPrimary)
+        }
+    }
+
+    private var presetOptions: [String] {
+        purifier.status.presetModes.isEmpty ? ["auto", "night"] : purifier.status.presetModes
+    }
+}
+
+/// Sheet wrapper presenting the air purifier controls, mirroring
+/// RobotDetailView so the purifier can be opened from the appliances grid.
+struct AirPurifierDetailView: View {
+    @Bindable var purifier: AirPurifier
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                AirPurifierView(purifier: purifier)
+                    .padding()
+            }
+            #if os(visionOS)
+            .glassBackgroundEffect()
+            #else
+            .background(Theme.Colors.background)
+            #endif
+            .navigationTitle("Air Purifier")
+            #if !os(macOS)
+            .navigationBarTitleDisplayMode(.inline)
+            #endif
+        }
+    }
+}
+
+#if DEBUG
+#Preview {
+    AirPurifierView(purifier: {
+        let purifier = AirPurifier()
+        purifier.status = AirPurifierState(
+            online: true,
+            fanOn: true,
+            presetMode: "auto",
+            presetModes: ["auto", "night"],
+            lightOn: true,
+            brightness: 255,
+            pm25: 4,
+            filterLife: 100
+        )
+        return purifier
+    }())
+}
+#endif

--- a/Shared/Api.swift
+++ b/Shared/Api.swift
@@ -123,6 +123,18 @@ struct MockData {
                 endBattery: 85,
                 gearMode: 3
             )
+        ),
+        airPurifier: AirPurifierState(
+            timestamp: "2024-12-13T11:55:00Z",
+            online: true,
+            fanOn: true,
+            fanSpeed: nil,
+            presetMode: "auto",
+            presetModes: ["auto", "night"],
+            lightOn: true,
+            brightness: 255,
+            pm25: 4,
+            filterLife: 100
         )
     )
 
@@ -165,6 +177,13 @@ struct MockData {
 
     static func createBattery() -> Battery {
         return Battery()
+    }
+
+    static func createAirPurifier() -> AirPurifier {
+        let purifier = AirPurifier()
+        let api = createApi()
+        purifier.setApiResponse(apiResponse: api)
+        return purifier
     }
 }
 #endif

--- a/Shared/AppliancesDetailView.swift
+++ b/Shared/AppliancesDetailView.swift
@@ -9,6 +9,7 @@ struct AppliancesDetailView: View {
     var miele: Miele
     var apiResponse: Api
     var robots: Robots
+    var airPurifier: AirPurifier
     @State private var showBroomBotSheet = false
     @State private var showMopBotSheet = false
     @State private var robotActionPending: String?
@@ -23,6 +24,7 @@ struct AppliancesDetailView: View {
                 }
                 robotCard(robot: robots.broomBot)
                 robotCard(robot: robots.mopBot)
+                AirPurifierView(purifier: airPurifier)
             }
             .padding()
         }
@@ -44,9 +46,11 @@ struct AppliancesDetailView: View {
         let isActive = robot.running == true || robot.paused == true
         let isPending = robotActionPending == robot.name
         applianceCard(
-            icon: robot.name == "MopBot" ? "humidifier.and.droplets" : "fan.fill",
+            icon: robot.name == "MopBot" ? "humidifier.and.droplets" : "robotic.vacuum.fill",
             name: robot.name ?? "Robot",
-            iconColor: robotIconColor(robot)
+            iconColor: robotIconColor(robot),
+            animation: robot.name == "MopBot" ? .variableColor : nil,
+            animationActive: isActive
         ) {
             VStack(alignment: .leading, spacing: 12) {
                 robotDetails(robot: robot, isActive: isActive)
@@ -167,13 +171,22 @@ struct AppliancesDetailView: View {
         icon: String,
         name: String,
         iconColor: Color,
+        animation: DeviceSymbolAnimation? = nil,
+        animationActive: Bool = false,
         @ViewBuilder content: () -> Content
     ) -> some View {
         VStack(alignment: .leading, spacing: 12) {
             HStack {
-                Image(systemName: icon)
-                    .font(Theme.Fonts.headerLarge())
-                    .foregroundColor(iconColor)
+                Group {
+                    if let animation {
+                        Image(systemName: icon)
+                            .deviceSymbolAnimation(animation, isActive: animationActive)
+                    } else {
+                        Image(systemName: icon)
+                    }
+                }
+                .font(Theme.Fonts.headerLarge())
+                .foregroundColor(iconColor)
                 Text(name)
                     .font(Theme.Fonts.headerLarge())
                     .foregroundColor(Theme.Colors.textPrimary)
@@ -468,7 +481,8 @@ private extension AppliancesDetailView {
         hconn: MockData.createHomeConnect(),
         miele: MockData.createMiele(),
         apiResponse: MockData.createApi(),
-        robots: MockData.createRobots()
+        robots: MockData.createRobots(),
+        airPurifier: MockData.createAirPurifier()
     )
 }
 #endif

--- a/Shared/AppliancesView.swift
+++ b/Shared/AppliancesView.swift
@@ -17,11 +17,13 @@ struct Appliances: View {
     var battery: Battery
     var car: Car
     var locationManager: LocationManager
+    var airPurifier: AirPurifier
 
     @State private var showCarModal: Bool = false
     @State private var showScooterModal: Bool = false
     @State private var showBroomBotModal: Bool = false
     @State private var showMopBotModal: Bool = false
+    @State private var showAirPurifierModal: Bool = false
     @State private var showApplianceModal: [String: Bool] = [:]
     @State var theAppliances: [(name: String, index: Int)] = []
 
@@ -35,7 +37,8 @@ struct Appliances: View {
         (name: "MopBot", index: 0),
         (name: "Car", index: 0),
         (name: "Scooter", index: 0),
-        (name: "Battery", index: 0)
+        (name: "Battery", index: 0),
+        (name: "AirPurifier", index: 0)
     ]
 
     var body: some View {
@@ -120,6 +123,8 @@ struct Appliances: View {
                                         self.showMopBotModal = true
                                     } else if theAppliances[app].name == "BroomBot" {
                                         self.showBroomBotModal = true
+                                    } else if theAppliances[app].name == "AirPurifier" {
+                                        self.showAirPurifierModal = true
                                     } else  if theAppliances[app].name != "Battery" {
                                         self.showApplianceModal[
                                             "\(theAppliances[app].name)-\(theAppliances[app].index)"
@@ -149,6 +154,9 @@ struct Appliances: View {
         }
         .sheet(isPresented: self.$showMopBotModal) {
             RobotDetailView(robot: robots.mopBot, robots: robots)
+        }
+        .sheet(isPresented: self.$showAirPurifierModal) {
+            AirPurifierDetailView(purifier: airPurifier)
         }
     }
 
@@ -185,6 +193,7 @@ struct Appliances: View {
             hconn.setApiResponse(apiResponse: self.apiResponse)
             miele.setApiResponse(apiResponse: self.apiResponse)
             car.setApiResponse(apiResponse: apiResponse)
+            airPurifier.setApiResponse(apiResponse: apiResponse)
             self.sortAppliances()
             return
         }
@@ -195,6 +204,7 @@ struct Appliances: View {
             hconn.setApiResponse(apiResponse: self.apiResponse)
             miele.setApiResponse(apiResponse: self.apiResponse)
             car.setApiResponse(apiResponse: apiResponse)
+            airPurifier.setApiResponse(apiResponse: apiResponse)
             self.sortAppliances()
         }
     }
@@ -206,44 +216,34 @@ struct Appliances: View {
         var inactiveAppliances: [(name: String, index: Int)] = []
 
         appliances.forEach { appliance in
-            let name = appliance.name
-            let index = appliance.index
-            switch name {
-            case "Car", "Scooter", "Battery":
+            if isApplianceActive(name: appliance.name, index: appliance.index) {
                 activeAppliances.append(appliance)
-            case "MopBot":
-                if robots.mopBot.running != nil && (robots.mopBot.running == true || robots.mopBot.paused == true) {
-                    activeAppliances.append(appliance)
-                } else {
-                    inactiveAppliances.append(appliance)
-                }
-            case "BroomBot":
-                if robots.broomBot.running != nil &&
-                    (robots.broomBot.running == true || robots.broomBot.paused == true) {
-                    activeAppliances.append(appliance)
-                } else {
-                    inactiveAppliances.append(appliance)
-                }
-            case "Miele":
-                let tAppliance = miele.appliances
-                if tApplianceTimeRemaining(tAppliance: tAppliance, index: index) == "Off" {
-                    inactiveAppliances.append(appliance)
-                } else {
-                    activeAppliances.append(appliance)
-                }
-            case "HomeConnect":
-                let tAppliance = hconn.appliances
-                if tApplianceTimeRemaining(tAppliance: tAppliance, index: index) == "Off" {
-                    inactiveAppliances.append(appliance)
-                } else {
-                    activeAppliances.append(appliance)
-                }
-            default:
-                break
+            } else {
+                inactiveAppliances.append(appliance)
             }
         }
 
         theAppliances = activeAppliances + inactiveAppliances
+    }
+
+    private func isApplianceActive(name: String, index: Int) -> Bool {
+        switch name {
+        case "Car", "Scooter", "Battery":
+            return true
+        case "MopBot":
+            return robots.mopBot.running != nil && (robots.mopBot.running == true || robots.mopBot.paused == true)
+        case "AirPurifier":
+            return airPurifier.status.online && airPurifier.status.fanOn
+        case "BroomBot":
+            return robots.broomBot.running != nil &&
+                (robots.broomBot.running == true || robots.broomBot.paused == true)
+        case "Miele":
+            return tApplianceTimeRemaining(tAppliance: miele.appliances, index: index) != "Off"
+        case "HomeConnect":
+            return tApplianceTimeRemaining(tAppliance: hconn.appliances, index: index) != "Off"
+        default:
+            return false
+        }
     }
 }
 
@@ -284,7 +284,8 @@ struct AppliancesPreviewWrapper: View {
             robots: robots,
             battery: battery,
             car: car,
-            locationManager: locationManager
+            locationManager: locationManager,
+            airPurifier: MockData.createAirPurifier()
         )
     }
 }

--- a/Shared/AppliancesViewExtensions.swift
+++ b/Shared/AppliancesViewExtensions.swift
@@ -16,6 +16,9 @@ extension Appliances {
             return getRobotIconColor(robot: robots.mopBot)
         case "BroomBot":
             return getRobotIconColor(robot: robots.broomBot)
+        case "AirPurifier":
+            return airPurifier.status.online && airPurifier.status.fanOn
+                ? Theme.Colors.accent : Theme.Colors.textSecondary
         case "Battery":
             return getBatteryIconColor()
         case "Car":
@@ -76,8 +79,11 @@ extension Appliances {
         switch type {
         case "MopBot":
             Image(systemName: "humidifier.and.droplets")
+                .deviceSymbolAnimation(.variableColor, isActive: robotIsActive(robots.mopBot))
         case "BroomBot":
-            Image(systemName: "fan")
+            Image(systemName: "robotic.vacuum.fill")
+        case "AirPurifier":
+            Image(systemName: "air.purifier")
         case "Battery":
             getDeviceIcon(battery: battery)
         case "Car":
@@ -90,6 +96,10 @@ extension Appliances {
         default:
             applianceIcon(for: hconn.appliances, index: index)
         }
+    }
+
+    private func robotIsActive(_ robot: Robot) -> Bool {
+        robot.running == true || robot.paused == true
     }
 
     private func applianceIcon(for appliances: [Appliance], index: Int) -> Image {
@@ -109,16 +119,10 @@ extension Appliances {
             return "MopBot"
         } else if type == "BroomBot" {
             return "BroomBot"
+        } else if type == "AirPurifier" {
+            return "Air Purifier"
         } else if type == "Battery" {
-            if battery.model == .iPad {
-                return "iPad"
-            } else if battery.model == .mac {
-                return "Computer"
-            } else if battery.model == .visionPro {
-                return "Vision Pro"
-            } else {
-                return "Phone"
-            }
+            return batteryName()
         } else if type == "Car" {
             return "Car"
         } else if type == "Scooter" {
@@ -132,6 +136,18 @@ extension Appliances {
             return text
         }
         return "Fetching"
+    }
+
+    private func batteryName() -> String {
+        if battery.model == .iPad {
+            return "iPad"
+        } else if battery.model == .mac {
+            return "Computer"
+        } else if battery.model == .visionPro {
+            return "Vision Pro"
+        } else {
+            return "Phone"
+        }
     }
 
     func tApplianceValue(tAppliance: [Appliance], index: Int) -> String {
@@ -159,6 +175,8 @@ extension Appliances {
            return getMopBotText()
         } else if type == "BroomBot" {
            return getBroomBotText()
+        } else if type == "AirPurifier" {
+           return getAirPurifierText()
         } else if type == "Battery" {
             if battery.state == .charging {
                 return "Charging"
@@ -204,6 +222,18 @@ extension Appliances {
         return text
     }
 
+    func getAirPurifierText() -> String {
+        guard airPurifier.status.online else { return "Offline" }
+        var parts: [String] = []
+        if airPurifier.status.fanOn {
+            parts.append(airPurifier.status.presetMode?.capitalized ?? "On")
+        }
+        if airPurifier.status.pm25 != nil {
+            parts.append("PM2.5 \(airPurifier.formattedPm25)")
+        }
+        return parts.joined(separator: " | ")
+    }
+
     func tApplianceTimeRemaining(tAppliance: [Appliance], index: Int) -> String {
         if tAppliance.count == 0 { return "" }
         if tAppliance[index].inUse == false {
@@ -220,6 +250,9 @@ extension Appliances {
             return robotStatus(robots.mopBot)
         } else if type == "BroomBot" {
             return robotStatus(robots.broomBot)
+        } else if type == "AirPurifier" {
+            if !airPurifier.status.online { return "Off" }
+            return airPurifier.status.fanOn ? "On" : "Off"
         } else if type == "Battery" {
             return "\(battery.percent)%"
         } else if type == "Car" {

--- a/Shared/LoginStucts.swift
+++ b/Shared/LoginStucts.swift
@@ -367,6 +367,7 @@ public struct LoginResponse: Codable {
     public let dryer: WasherDryer?
     public let washer: WasherDryer?
     public let scooter: ScooterSummary?
+    public let airPurifier: AirPurifierState?
 
     public init(
         timestamp: String,
@@ -380,7 +381,8 @@ public struct LoginResponse: Codable {
         dishwasher: DishWasher? = nil,
         dryer: WasherDryer? = nil,
         washer: WasherDryer? = nil,
-        scooter: ScooterSummary? = nil
+        scooter: ScooterSummary? = nil,
+        airPurifier: AirPurifierState? = nil
     ) {
         self.timestamp = timestamp
         self.favouriteHomeKit = favouriteHomeKit
@@ -394,6 +396,7 @@ public struct LoginResponse: Codable {
         self.dryer = dryer
         self.washer = washer
         self.scooter = scooter
+        self.airPurifier = airPurifier
     }
 }
 

--- a/Shared/Metrics.swift
+++ b/Shared/Metrics.swift
@@ -1,0 +1,201 @@
+//
+//  Metrics.swift
+//  FluxHaus
+//
+//  Fetches server-defined metric catalog and time-series data for the
+//  metrics dashboard. The app only references metric ids — all queries
+//  (Flux / PromQL) are defined server-side.
+//
+
+import Foundation
+import os
+
+private let logger = Logger(subsystem: "io.fluxhaus.FluxHaus", category: "Metrics")
+
+public enum MetricRange: String, CaseIterable, Identifiable {
+    case hour = "1h"
+    case sixHours = "6h"
+    case day = "24h"
+    case week = "7d"
+    case month = "30d"
+
+    public var id: String { rawValue }
+
+    public var label: String {
+        switch self {
+        case .hour: return "1H"
+        case .sixHours: return "6H"
+        case .day: return "24H"
+        case .week: return "7D"
+        case .month: return "30D"
+        }
+    }
+}
+
+public struct MetricCatalogItem: Codable, Identifiable, Hashable, Sendable {
+    public let id: String
+    public let title: String
+    public let unit: String
+    public let group: String
+}
+
+private struct MetricCatalogResponse: Codable {
+    let metrics: [MetricCatalogItem]
+}
+
+public struct MetricPoint: Codable, Hashable, Sendable {
+    public let time: String
+    public let value: Double
+
+    enum CodingKeys: String, CodingKey {
+        case time = "t"
+        case value = "v"
+    }
+
+    public var date: Date? {
+        MetricPoint.parse(time)
+    }
+
+    nonisolated(unsafe) private static let formatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    nonisolated(unsafe) private static let plainFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter
+    }()
+
+    static func parse(_ value: String) -> Date? {
+        formatter.date(from: value) ?? plainFormatter.date(from: value)
+    }
+}
+
+public struct MetricSeries: Codable, Identifiable, Hashable, Sendable {
+    public var id: String { name }
+    public let name: String
+    public let points: [MetricPoint]
+}
+
+public struct MetricSeriesResponse: Codable, Sendable {
+    public let metric: String
+    public let title: String
+    public let unit: String
+    public let range: String
+    public let series: [MetricSeries]
+}
+
+@MainActor
+@Observable class MetricsService {
+    var catalog: [MetricCatalogItem] = []
+    var series: [String: MetricSeriesResponse] = [:]
+    var selectedRange: MetricRange = .day
+    var isLoading = false
+    var isRefreshing = false
+    var lastError: String?
+
+    var groupedCatalog: [(group: String, metrics: [MetricCatalogItem])] {
+        let visible = catalog.filter { $0.group.lowercased() != "system" }
+        let groups = Dictionary(grouping: visible, by: { $0.group })
+        return groups.keys.sorted(by: MetricsService.groupSort).map { key in
+            (group: key, metrics: groups[key] ?? [])
+        }
+    }
+
+    /// Preferred group ordering: Environment first, then Car, then the rest
+    /// alphabetically. "System" is filtered out entirely.
+    private static func groupSort(_ lhs: String, _ rhs: String) -> Bool {
+        func rank(_ group: String) -> Int {
+            switch group.lowercased() {
+            case "environment": return 0
+            case "car": return 1
+            default: return 2
+            }
+        }
+        let lRank = rank(lhs), rRank = rank(rhs)
+        if lRank != rRank { return lRank < rRank }
+        return lhs < rhs
+    }
+
+    func refresh() async {
+        isLoading = true
+        lastError = nil
+        await loadCatalog()
+        await loadAllSeries()
+        isLoading = false
+    }
+
+    func loadCatalog() async {
+        guard let data = await get(path: "/metrics/catalog", query: []) else { return }
+        do {
+            let decoded = try JSONDecoder().decode(MetricCatalogResponse.self, from: data)
+            catalog = decoded.metrics
+        } catch {
+            logger.error("Failed to decode metric catalog: \(error.localizedDescription)")
+            lastError = "Could not load metrics"
+        }
+    }
+
+    func loadAllSeries() async {
+        isRefreshing = true
+        defer { isRefreshing = false }
+        let range = selectedRange
+        var results: [String: MetricSeriesResponse] = [:]
+        for metric in catalog {
+            if let response = await fetchSeries(metricId: metric.id, range: range) {
+                results[metric.id] = response
+            }
+        }
+        series = results
+    }
+
+    func fetchSeries(metricId: String, range: MetricRange) async -> MetricSeriesResponse? {
+        let query = [
+            URLQueryItem(name: "metric", value: metricId),
+            URLQueryItem(name: "range", value: range.rawValue)
+        ]
+        guard let data = await get(path: "/metrics/series", query: query) else { return nil }
+        do {
+            return try JSONDecoder().decode(MetricSeriesResponse.self, from: data)
+        } catch {
+            logger.error("Failed to decode series \(metricId): \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    private func get(path: String, query: [URLQueryItem]) async -> Data? {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = "api.fluxhaus.io"
+        components.path = path
+        if !query.isEmpty { components.queryItems = query }
+        guard let url = components.url else { return nil }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.addValue("application/json", forHTTPHeaderField: "Accept")
+        if let authHeader = AuthManager.shared.authorizationHeader() {
+            request.setValue(authHeader, forHTTPHeaderField: "Authorization")
+        } else {
+            let password = WhereWeAre.getPassword() ?? ""
+            let base64 = Data("demo:\(password)".utf8).base64EncodedString()
+            request.setValue("Basic \(base64)", forHTTPHeaderField: "Authorization")
+        }
+
+        do {
+            let session = URLSession(configuration: .default)
+            let (data, response) = try await session.data(for: request)
+            let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+            guard (200...299).contains(statusCode) else {
+                logger.error("Metrics GET \(path) returned HTTP \(statusCode)")
+                return nil
+            }
+            return data
+        } catch {
+            logger.error("Metrics GET \(path) failed: \(error.localizedDescription)")
+            return nil
+        }
+    }
+}

--- a/Shared/Metrics.swift
+++ b/Shared/Metrics.swift
@@ -148,6 +148,10 @@ public struct MetricSeriesResponse: Codable, Sendable {
                 results[metric.id] = response
             }
         }
+        // The range may have changed while requests were in flight; discard
+        // results that no longer match the current selection so the UI never
+        // shows series for the wrong range.
+        guard range == selectedRange else { return }
         series = results
     }
 
@@ -190,11 +194,14 @@ public struct MetricSeriesResponse: Codable, Sendable {
             let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
             guard (200...299).contains(statusCode) else {
                 logger.error("Metrics GET \(path) returned HTTP \(statusCode)")
+                lastError = "Could not load metrics (HTTP \(statusCode))"
                 return nil
             }
+            lastError = nil
             return data
         } catch {
             logger.error("Metrics GET \(path) failed: \(error.localizedDescription)")
+            lastError = "Could not load metrics"
             return nil
         }
     }

--- a/Shared/MetricsView.swift
+++ b/Shared/MetricsView.swift
@@ -1,0 +1,268 @@
+//
+//  MetricsView.swift
+//  FluxHaus
+//
+//  Grafana-style metrics dashboard — one chart per stat with a line per
+//  series (room, vehicle, host, …).
+//
+
+import SwiftUI
+import Charts
+
+struct MetricsView: View {
+    @Bindable var metrics: MetricsService
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.large) {
+            header
+            rangePicker
+            content
+        }
+        .padding(.vertical)
+        .task {
+            if metrics.catalog.isEmpty {
+                await metrics.refresh()
+            }
+            // Keep the dashboard live: refresh series periodically until the
+            // view goes away (the task is cancelled automatically on disappear).
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(30))
+                if Task.isCancelled { break }
+                await metrics.loadAllSeries()
+            }
+        }
+    }
+
+    private var header: some View {
+        HStack {
+            Text("Metrics")
+                .font(Theme.Fonts.headerLarge())
+                .foregroundColor(Theme.Colors.textPrimary)
+            Spacer()
+            Button {
+                Task { await metrics.refresh() }
+            } label: {
+                Image(systemName: "arrow.clockwise")
+                    .foregroundColor(Theme.Colors.accent)
+                    .symbolEffect(
+                        .rotate,
+                        options: .repeat(.continuous),
+                        isActive: metrics.isLoading || metrics.isRefreshing
+                    )
+            }
+            .buttonStyle(.plain)
+            .disabled(metrics.isLoading || metrics.isRefreshing)
+        }
+        .padding(.horizontal)
+    }
+
+    private var rangePicker: some View {
+        Picker("Range", selection: $metrics.selectedRange) {
+            ForEach(MetricRange.allCases) { range in
+                Text(range.label).tag(range)
+            }
+        }
+        .pickerStyle(.segmented)
+        .padding(.horizontal)
+        .onChange(of: metrics.selectedRange) {
+            Task { await metrics.loadAllSeries() }
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if metrics.catalog.isEmpty && !metrics.isLoading {
+            emptyState
+        } else {
+            ForEach(metrics.groupedCatalog, id: \.group) { section in
+                VStack(alignment: .leading, spacing: Theme.Spacing.medium) {
+                    Text(section.group)
+                        .font(Theme.Fonts.bodySmall)
+                        .foregroundColor(Theme.Colors.textSecondary)
+                        .padding(.horizontal)
+                    ForEach(section.metrics) { metric in
+                        MetricChartCard(metric: metric, response: metrics.series[metric.id])
+                    }
+                }
+            }
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: Theme.Spacing.small) {
+            Image(systemName: "chart.xyaxis.line")
+                .font(.largeTitle)
+                .foregroundColor(Theme.Colors.textSecondary)
+            Text(metrics.lastError ?? "No metrics available")
+                .font(Theme.Fonts.bodyMedium)
+                .foregroundColor(Theme.Colors.textSecondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.top, 40)
+    }
+}
+
+struct MetricChartCard: View {
+    let metric: MetricCatalogItem
+    let response: MetricSeriesResponse?
+
+    @State private var selectedDate: Date?
+
+    private var series: [MetricSeries] {
+        (response?.series ?? []).filter { !$0.points.isEmpty }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.small) {
+            HStack {
+                Text(metric.title)
+                    .font(Theme.Fonts.bodyLarge)
+                    .foregroundColor(Theme.Colors.textPrimary)
+                Spacer()
+                Text(metric.unit)
+                    .font(Theme.Fonts.caption)
+                    .foregroundColor(Theme.Colors.textSecondary)
+            }
+            if series.isEmpty {
+                Text("No data")
+                    .font(Theme.Fonts.bodySmall)
+                    .foregroundColor(Theme.Colors.textSecondary)
+                    .frame(maxWidth: .infinity, minHeight: 120)
+            } else {
+                readout
+                chart
+            }
+        }
+        .padding()
+        .background(Theme.Colors.secondaryBackground)
+        .cornerRadius(Theme.cornerRadius)
+        .padding(.horizontal)
+    }
+
+    /// Y-axis domain derived from the data with a little padding so flat-ish
+    /// series don't get stretched across the full height.
+    private var yDomain: ClosedRange<Double>? {
+        let values = series.flatMap { $0.points.map(\.value) }
+        guard let minValue = values.min(), let maxValue = values.max() else { return nil }
+        if minValue == maxValue {
+            let pad = abs(minValue) * 0.05
+            let delta = pad == 0 ? 1 : pad
+            return (minValue - delta)...(maxValue + delta)
+        }
+        let pad = (maxValue - minValue) * 0.1
+        return (minValue - pad)...(maxValue + pad)
+    }
+
+    private var sortedDates: [Date] {
+        Array(Set(series.flatMap { $0.points.compactMap(\.date) })).sorted()
+    }
+
+    private var latestDate: Date? { sortedDates.last }
+
+    private var snappedDate: Date? {
+        guard let selectedDate else { return nil }
+        return sortedDates.min(by: {
+            abs($0.timeIntervalSince(selectedDate)) < abs($1.timeIntervalSince(selectedDate))
+        })
+    }
+
+    private func value(for line: MetricSeries, at date: Date) -> Double? {
+        line.points.min(by: {
+            abs(($0.date ?? .distantPast).timeIntervalSince(date))
+                < abs(($1.date ?? .distantPast).timeIntervalSince(date))
+        })?.value
+    }
+
+    /// Always-visible readout row. Shows values at the hovered/touched time,
+    /// or the most recent reading when nothing is selected. Kept outside the
+    /// chart so it's never clipped, even with many series.
+    private var readout: some View {
+        let date = snappedDate ?? latestDate
+        return ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 12) {
+                if let date {
+                    Text(date.formatted(date: .omitted, time: .shortened))
+                        .foregroundColor(Theme.Colors.textSecondary)
+                    ForEach(series) { line in
+                        if let value = value(for: line, at: date) {
+                            HStack(spacing: 4) {
+                                if series.count > 1 {
+                                    Text(line.name)
+                                        .foregroundColor(Theme.Colors.textSecondary)
+                                }
+                                Text("\(value, specifier: "%.1f")\(metric.unit)")
+                                    .foregroundColor(Theme.Colors.textPrimary)
+                            }
+                        }
+                    }
+                }
+            }
+            .font(Theme.Fonts.caption)
+        }
+        .frame(height: 18)
+    }
+
+    private var chart: some View {
+        Chart {
+            ForEach(series) { line in
+                ForEach(line.points, id: \.time) { point in
+                    if let date = point.date {
+                        LineMark(
+                            x: .value("Time", date),
+                            y: .value(metric.unit, point.value)
+                        )
+                        .foregroundStyle(by: .value("Series", line.name))
+                        .interpolationMethod(.catmullRom)
+                    }
+                }
+            }
+            if let snappedDate {
+                RuleMark(x: .value("Time", snappedDate))
+                    .foregroundStyle(Theme.Colors.textSecondary.opacity(0.4))
+                ForEach(series) { line in
+                    if let value = value(for: line, at: snappedDate) {
+                        PointMark(
+                            x: .value("Time", snappedDate),
+                            y: .value(metric.unit, value)
+                        )
+                        .foregroundStyle(by: .value("Series", line.name))
+                        .symbolSize(60)
+                    }
+                }
+            }
+        }
+        .chartLegend(series.count > 1 ? .visible : .hidden)
+        .chartYAxis {
+            AxisMarks(position: .leading)
+        }
+        .chartYScale(domain: yDomain ?? 0...1)
+        .chartXSelection(value: $selectedDate)
+        .frame(height: 180)
+    }
+}
+
+#if DEBUG
+#Preview {
+    ScrollView {
+        MetricChartCard(
+            metric: MetricCatalogItem(id: "temperature", title: "Temperature", unit: "°C", group: "Environment"),
+            response: MetricSeriesResponse(
+                metric: "temperature",
+                title: "Temperature",
+                unit: "°C",
+                range: "24h",
+                series: [
+                    MetricSeries(name: "Bedroom", points: [
+                        MetricPoint(time: "2024-01-01T00:00:00Z", value: 21),
+                        MetricPoint(time: "2024-01-01T01:00:00Z", value: 21.6)
+                    ]),
+                    MetricSeries(name: "Kitchen", points: [
+                        MetricPoint(time: "2024-01-01T00:00:00Z", value: 22.8),
+                        MetricPoint(time: "2024-01-01T01:00:00Z", value: 23.1)
+                    ])
+                ]
+            )
+        )
+    }
+}
+#endif

--- a/Shared/NotificationSettingsView.swift
+++ b/Shared/NotificationSettingsView.swift
@@ -16,7 +16,7 @@ struct NotificationSettingsSection: View {
         ("Dishwasher", "dishwasher"),
         ("Washer", "washer"),
         ("Dryer", "dryer"),
-        ("BroomBot", "fan"),
+        ("BroomBot", "robotic.vacuum"),
         ("MopBot", "humidifier.and.droplets")
     ]
 

--- a/Shared/QueryFluxWidgetExtensions.swift
+++ b/Shared/QueryFluxWidgetExtensions.swift
@@ -149,7 +149,7 @@ func convertDataToWidgetDevices(fluxData: FluxData) -> [WidgetDevice] {
         WidgetDevice(
             name: "BroomBot",
             progress: fluxData.broomBot?.batteryLevel ?? 0,
-            icon: "fan",
+            icon: "robotic.vacuum",
             trailingText: fluxData.broomBot?.running ?? false ? "On" : "Off",
             shortText: fluxData.broomBot?.running ?? false ? "On" : "Off",
             running: fluxData.broomBot?.running ?? false,

--- a/Shared/RobotDetailView.swift
+++ b/Shared/RobotDetailView.swift
@@ -22,8 +22,12 @@ struct RobotDetailView: View {
                     HStack {
                         if robot.name! == "MopBot" {
                             Image(systemName: "humidifier.and.droplets")
+                                .deviceSymbolAnimation(
+                                    .variableColor,
+                                    isActive: robot.running == true || robot.paused == true
+                                )
                         } else {
-                            Image(systemName: "fan")
+                            Image(systemName: "robotic.vacuum.fill")
                         }
                         Text(robot.name!)
                     }

--- a/Shared/RobotsListView.swift
+++ b/Shared/RobotsListView.swift
@@ -18,15 +18,15 @@ struct RobotsListView: View {
                 robotCard(
                     title: "BroomBot",
                     robot: robots.broomBot,
-                    robotName: "broomBot",
-                    icon: "fan",
+                    icon: "robotic.vacuum.fill",
+                    animation: nil,
                     showSheet: $showBroomBotSheet
                 )
                 robotCard(
                     title: "MopBot",
                     robot: robots.mopBot,
-                    robotName: "mopBot",
                     icon: "humidifier.and.droplets",
+                    animation: .variableColor,
                     showSheet: $showMopBotSheet
                 )
             }
@@ -48,8 +48,8 @@ struct RobotsListView: View {
     private func robotCard(
         title: String,
         robot: Robot,
-        robotName: String,
         icon: String,
+        animation: DeviceSymbolAnimation?,
         showSheet: Binding<Bool>
     ) -> some View {
         Button(action: { showSheet.wrappedValue = true }, label: {
@@ -57,6 +57,7 @@ struct RobotsListView: View {
                 HStack {
                     Image(systemName: icon)
                         .foregroundColor(statusColor(robot))
+                        .deviceSymbolAnimation(animation, isActive: robot.running == true || robot.paused == true)
                     Text(title)
                         .font(Theme.Fonts.headerLarge())
                         .foregroundColor(Theme.Colors.textPrimary)

--- a/Shared/SuggestionChips.swift
+++ b/Shared/SuggestionChips.swift
@@ -16,7 +16,7 @@ struct SuggestionChip: Identifiable {
 
 let defaultSuggestions: [SuggestionChip] = [
     SuggestionChip(label: "Home status", icon: "house", command: "What's the home status?"),
-    SuggestionChip(label: "Start BroomBot", icon: "fan", command: "Start the broombot"),
+    SuggestionChip(label: "Start BroomBot", icon: "robotic.vacuum", command: "Start the broombot"),
     SuggestionChip(label: "Appliances", icon: "washer", command: "Check the appliances"),
     SuggestionChip(label: "Car status", icon: "bolt.car", command: "What's the car status?"),
     SuggestionChip(

--- a/Shared/SymbolAnimation.swift
+++ b/Shared/SymbolAnimation.swift
@@ -1,0 +1,66 @@
+//
+//  SymbolAnimation.swift
+//  FluxHaus
+//
+//  Central helpers for animating SF Symbols on device icons.
+//
+
+import SwiftUI
+
+/// Testing switch: when `true`, every animatable device symbol animates
+/// regardless of whether the underlying device is active. Flip to `false`
+/// so symbols only animate when their device is actually on/running.
+enum SymbolAnimationTesting {
+    static let forceAll = false
+}
+
+/// Logical animation styles mapped to device behaviour.
+enum DeviceSymbolAnimation {
+    /// Spinning motion — robot vacuum, laundry drum, etc.
+    case rotate
+    /// Gentle pulse — vehicles preparing/charging.
+    case pulse
+    /// Flowing colour — water/moisture (mop) devices.
+    case variableColor
+    /// Breathing scale — air moving through a purifier.
+    case breathe
+    /// Vibration — a running machine.
+    case wiggle
+}
+
+private struct DeviceSymbolAnimationModifier: ViewModifier {
+    let animation: DeviceSymbolAnimation
+    let isActive: Bool
+
+    private var active: Bool { isActive || SymbolAnimationTesting.forceAll }
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        switch animation {
+        case .rotate:
+            content.symbolEffect(.rotate, options: .repeating, isActive: active)
+        case .pulse:
+            content.symbolEffect(.pulse, options: .repeating, isActive: active)
+        case .variableColor:
+            content.symbolEffect(.variableColor, options: .repeating, isActive: active)
+        case .breathe:
+            content.symbolEffect(.breathe, options: .repeating, isActive: active)
+        case .wiggle:
+            content.symbolEffect(.wiggle, options: .repeating, isActive: active)
+        }
+    }
+}
+
+extension View {
+    /// Applies a repeating SF Symbol effect while the device is active (or
+    /// always, when `SymbolAnimationTesting.forceAll` is enabled). Passing a
+    /// `nil` animation leaves the view untouched.
+    @ViewBuilder
+    func deviceSymbolAnimation(_ animation: DeviceSymbolAnimation?, isActive: Bool) -> some View {
+        if let animation {
+            modifier(DeviceSymbolAnimationModifier(animation: animation, isActive: isActive))
+        } else {
+            self
+        }
+    }
+}

--- a/Tests iOS/MockDataUITests.swift
+++ b/Tests iOS/MockDataUITests.swift
@@ -299,7 +299,7 @@ struct ApplianceDisplayTests {
         await drainMainQueue()
 
         let view = mockAppliances(hconn: hconn, miele: miele, robots: robots, car: car)
-        #expect(view.originalAppliances.count == 8)
+        #expect(view.originalAppliances.count == 9)
         let names = view.originalAppliances.map { $0.name }
         #expect(names.contains("HomeConnect"))
         #expect(names.contains("Miele"))
@@ -308,6 +308,7 @@ struct ApplianceDisplayTests {
         #expect(names.contains("Car"))
         #expect(names.contains("Scooter"))
         #expect(names.contains("Battery"))
+        #expect(names.contains("AirPurifier"))
     }
 
     @Test("Appliance names are correct for each type")

--- a/Tests iOS/MockDataUITests.swift
+++ b/Tests iOS/MockDataUITests.swift
@@ -136,7 +136,9 @@ struct ViewSmokeTests {
             battery: MockData.createBattery(),
             car: car,
             scooter: MockData.createScooter(),
-            apiResponse: MockData.createApi()
+            apiResponse: MockData.createApi(),
+            airPurifier: MockData.createAirPurifier(),
+            metrics: MetricsService()
         )
 
         let controller = UIHostingController(rootView: view)
@@ -433,7 +435,9 @@ struct NilDataResilienceTests {
             fluxHausConsts: FluxHausConsts(),
             hconn: hconn, miele: miele, robots: robots,
             battery: Battery(), car: car,
-            scooter: MockData.createScooter(), apiResponse: api
+            scooter: MockData.createScooter(), apiResponse: api,
+            airPurifier: MockData.createAirPurifier(),
+            metrics: MetricsService()
         )
         let controller = UIHostingController(rootView: view)
         controller.loadViewIfNeeded()

--- a/Tests iOS/MockDataUITests.swift
+++ b/Tests iOS/MockDataUITests.swift
@@ -46,7 +46,8 @@ private func mockAppliances(
         hconn: hconn, miele: miele,
         apiResponse: MockData.createApi(),
         robots: robots, battery: battery,
-        car: car, locationManager: LocationManager()
+        car: car, locationManager: LocationManager(),
+        airPurifier: MockData.createAirPurifier()
     )
 }
 
@@ -162,7 +163,8 @@ struct ViewSmokeTests {
             robots: robots,
             battery: MockData.createBattery(),
             car: car,
-            locationManager: LocationManager()
+            locationManager: LocationManager(),
+            airPurifier: MockData.createAirPurifier()
         )
 
         let controller = UIHostingController(rootView: view)

--- a/Tests macOS/Tests_macOS_ViewTests.swift
+++ b/Tests macOS/Tests_macOS_ViewTests.swift
@@ -202,7 +202,7 @@ struct SidebarItemTests {
         #expect(SidebarItem.appliances.icon == "washer.fill")
         #expect(SidebarItem.car.icon == "car.fill")
         #expect(SidebarItem.scooter.icon == "scooter")
-        #expect(SidebarItem.robots.icon == "fan.fill")
+        #expect(SidebarItem.robots.icon == "robotic.vacuum.fill")
         #expect(
             SidebarItem.assistant.icon
             == "bubble.left.and.bubble.right.fill"

--- a/Tests macOS/Tests_macOS_ViewTests.swift
+++ b/Tests macOS/Tests_macOS_ViewTests.swift
@@ -77,6 +77,8 @@ struct MacOSViewSmokeTests {
             car: car,
             scooter: MockData.createScooter(),
             apiResponse: MockData.createApi(),
+            airPurifier: MockData.createAirPurifier(),
+            metrics: MetricsService(),
             chat: Chat()
         )
 
@@ -132,6 +134,7 @@ struct MacOSViewSmokeTests {
             car: car,
             scooter: MockData.createScooter(),
             apiResponse: MockData.createApi(),
+            airPurifier: MockData.createAirPurifier(),
             locationManager: LocationManager(),
             radarService: RadarService(),
             onNavigate: { _ in }
@@ -171,7 +174,7 @@ struct SidebarItemTests {
     @Test("SidebarItem has all expected cases")
     func testAllCases() {
         let items = SidebarItem.allCases
-        #expect(items.count == 8)
+        #expect(items.count == 9)
         #expect(items.contains(.dashboard))
         #expect(items.contains(.weather))
         #expect(items.contains(.scenes))
@@ -180,6 +183,7 @@ struct SidebarItemTests {
         #expect(items.contains(.scooter))
         #expect(items.contains(.robots))
         #expect(items.contains(.assistant))
+        #expect(items.contains(.metrics))
     }
 
     @Test("SidebarItem has correct display names")
@@ -192,6 +196,7 @@ struct SidebarItemTests {
         #expect(SidebarItem.scooter.rawValue == "Scooter")
         #expect(SidebarItem.robots.rawValue == "Robots")
         #expect(SidebarItem.assistant.rawValue == "Assistant")
+        #expect(SidebarItem.metrics.rawValue == "Metrics")
     }
 
     @Test("SidebarItem has correct icons")
@@ -207,6 +212,7 @@ struct SidebarItemTests {
             SidebarItem.assistant.icon
             == "bubble.left.and.bubble.right.fill"
         )
+        #expect(SidebarItem.metrics.icon == "chart.xyaxis.line")
     }
 
     @Test("SidebarItem ids are unique")
@@ -417,7 +423,10 @@ struct MacOSNilDataResilienceTests {
             hconn: hconn, miele: miele, robots: robots,
             battery: Battery(), car: car,
             scooter: MockData.createScooter(),
-            apiResponse: api, chat: Chat()
+            apiResponse: api,
+            airPurifier: MockData.createAirPurifier(),
+            metrics: MetricsService(),
+            chat: Chat()
         )
         let controller = NSHostingController(rootView: view)
         controller.loadView()
@@ -443,6 +452,7 @@ struct MacOSNilDataResilienceTests {
             battery: Battery(), car: car,
             scooter: MockData.createScooter(),
             apiResponse: api,
+            airPurifier: MockData.createAirPurifier(),
             locationManager: LocationManager(),
             radarService: RadarService(),
             onNavigate: { _ in }

--- a/VisionOS/ContentView.swift
+++ b/VisionOS/ContentView.swift
@@ -18,6 +18,8 @@ struct ContentView: View {
     var car: Car
     var scooter: Scooter
     var apiResponse: Api
+    var airPurifier: AirPurifier
+    var metrics: MetricsService
     @State private var whereWeAre = WhereWeAre()
     @State private var locationManager = LocationManager()
     @State private var authManager = AuthManager.shared
@@ -52,7 +54,7 @@ struct ContentView: View {
                 }
                 .tag("Scooter")
             RobotsListView(robots: robots)
-                .tabItem { Label("Robots", systemImage: "fan.fill") }
+                .tabItem { Label("Robots", systemImage: "robotic.vacuum.fill") }
                 .tag("Robots")
             if authManager.isOIDC {
                 ChatView(chat: chat)
@@ -61,6 +63,9 @@ struct ContentView: View {
                     }
                     .tag("Assistant")
             }
+            metricsTab
+                .tabItem { Label("Metrics", systemImage: "chart.xyaxis.line") }
+                .tag("Metrics")
         }
         .background { visionKeyboardShortcuts }
         .onReceive(
@@ -92,7 +97,8 @@ struct ContentView: View {
                     robots: robots,
                     battery: battery,
                     car: car,
-                    locationManager: locationManager
+                    locationManager: locationManager,
+                    airPurifier: airPurifier
                 )
             }
             .padding()
@@ -114,12 +120,19 @@ struct ContentView: View {
         ScooterDetailView(scooter: scooter)
     }
 
+    private var metricsTab: some View {
+        ScrollView {
+            MetricsView(metrics: metrics)
+        }
+    }
+
     private var appliancesTab: some View {
         AppliancesDetailView(
             hconn: hconn,
             miele: miele,
             apiResponse: apiResponse,
-            robots: robots
+            robots: robots,
+            airPurifier: airPurifier
         )
     }
 
@@ -133,6 +146,7 @@ struct ContentView: View {
             Button("") { selectedTab = "Scooter" }.keyboardShortcut("6")
             Button("") { selectedTab = "Robots" }.keyboardShortcut("7")
             Button("") { selectedTab = "Assistant" }.keyboardShortcut("8")
+            Button("") { selectedTab = "Metrics" }.keyboardShortcut("9")
         }
         .frame(width: 0, height: 0)
         .opacity(0)
@@ -153,7 +167,9 @@ struct ContentView: View {
         battery: MockData.createBattery(),
         car: MockData.createCar(),
         scooter: Scooter(),
-        apiResponse: MockData.createApi()
+        apiResponse: MockData.createApi(),
+        airPurifier: MockData.createAirPurifier(),
+        metrics: MetricsService()
     )
 }
 #endif

--- a/VisionOS/VisionOSApp.swift
+++ b/VisionOS/VisionOSApp.swift
@@ -23,6 +23,8 @@ struct VisionOSApp: App {
     @State private var battery: Battery?
     @State private var car: Car?
     @State private var scooter: Scooter?
+    @State private var airPurifier: AirPurifier?
+    @State private var metrics = MetricsService()
 
     @Environment(\.scenePhase) private var scenePhase
 
@@ -83,6 +85,7 @@ struct VisionOSApp: App {
                                 loadCar()
                                 loadScooter()
                                 loadHomeConnect()
+                                loadAirPurifier()
                             }
                         }
                 } else {
@@ -91,7 +94,8 @@ struct VisionOSApp: App {
                        let robots = robots,
                        let battery = battery,
                        let car = car,
-                       let scooter = scooter {
+                       let scooter = scooter,
+                       let airPurifier = airPurifier {
                         ContentView(
                             fluxHausConsts: fluxHausConsts,
                             hconn: hconn,
@@ -100,7 +104,9 @@ struct VisionOSApp: App {
                             battery: battery,
                             car: car,
                             scooter: scooter,
-                            apiResponse: self.apiResponse
+                            apiResponse: self.apiResponse,
+                            airPurifier: airPurifier,
+                            metrics: metrics
                         )
                         .onReceive(NotificationCenter.default.publisher(for: Notification.Name.dataUpdated)) { object in
                             if let response = object.userInfo?["data"] as? LoginResponse {
@@ -111,6 +117,7 @@ struct VisionOSApp: App {
                                 miele.setApiResponse(apiResponse: self.apiResponse)
                                 car.setApiResponse(apiResponse: self.apiResponse)
                                 scooter.setApiResponse(apiResponse: self.apiResponse)
+                                airPurifier.setApiResponse(apiResponse: self.apiResponse)
                             }
                         }
                         .task {
@@ -135,6 +142,7 @@ struct VisionOSApp: App {
                 robots = nil
                 car = nil
                 scooter = nil
+                airPurifier = nil
             }
             .onChange(of: scenePhase) { _, newPhase in
                 if newPhase == .active && AuthManager.shared.isSignedIn {
@@ -186,6 +194,11 @@ struct VisionOSApp: App {
     func loadScooter() {
         scooter = Scooter()
         scooter?.setApiResponse(apiResponse: self.apiResponse)
+    }
+
+    func loadAirPurifier() {
+        airPurifier = AirPurifier()
+        airPurifier?.setApiResponse(apiResponse: self.apiResponse)
     }
 
     private func runPeriodicRefresh() async {

--- a/iOS/CarPlay/CarPlaySceneDelegate.swift
+++ b/iOS/CarPlay/CarPlaySceneDelegate.swift
@@ -256,7 +256,7 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
             CPListItem(
                 text: "BroomBot",
                 detailText: robotStatusText(response.broombot),
-                image: UIImage(systemName: "fan")
+                image: UIImage(systemName: "robotic.vacuum")
             ),
             CPListItem(
                 text: "MopBot",

--- a/iOS/ContentView.swift
+++ b/iOS/ContentView.swift
@@ -16,6 +16,8 @@ struct ContentView: View {
     var car: Car
     var scooter: Scooter
     var apiResponse: Api
+    var airPurifier: AirPurifier
+    var metrics: MetricsService
     @State private var whereWeAre = WhereWeAre()
     @State private var locationManager = LocationManager()
     @State private var authManager = AuthManager.shared
@@ -63,7 +65,7 @@ struct ContentView: View {
                     scenesTab
                 }
                 .customizationID("scenes")
-                Tab("Robots", systemImage: "fan.fill", value: "robots") {
+                Tab("Robots", systemImage: "robotic.vacuum.fill", value: "robots") {
                     robotsTab
                 }
                 .customizationID("robots")
@@ -71,6 +73,10 @@ struct ContentView: View {
                     settingsTab
                 }
                 .customizationID("settings")
+                Tab("Metrics", systemImage: "chart.xyaxis.line", value: "metrics") {
+                    metricsTab
+                }
+                .customizationID("metrics")
             } header: {
                 Label("More", systemImage: "ellipsis")
             }
@@ -108,7 +114,8 @@ struct ContentView: View {
                 robots: robots,
                 battery: battery,
                 car: car,
-                locationManager: locationManager
+                locationManager: locationManager,
+                airPurifier: airPurifier
             )
             Spacer()
             footer
@@ -139,12 +146,20 @@ struct ContentView: View {
         RobotsListView(robots: robots)
     }
 
+    private var metricsTab: some View {
+        ScrollView {
+            MetricsView(metrics: metrics)
+        }
+        .background(Theme.Colors.background)
+    }
+
     private var appliancesTab: some View {
         AppliancesDetailView(
             hconn: hconn,
             miele: miele,
             apiResponse: apiResponse,
-            robots: robots
+            robots: robots,
+            airPurifier: airPurifier
         )
     }
 
@@ -198,7 +213,9 @@ struct ContentView: View {
         battery: MockData.createBattery(),
         car: MockData.createCar(),
         scooter: Scooter(),
-        apiResponse: MockData.createApi()
+        apiResponse: MockData.createApi(),
+        airPurifier: MockData.createAirPurifier(),
+        metrics: MetricsService()
     )
 }
 #endif

--- a/iOS/FluxHausApp.swift
+++ b/iOS/FluxHausApp.swift
@@ -154,6 +154,8 @@ struct FluxHausApp: App {
     @State private var robots: Robots?
     @State private var car: Car?
     @State private var scooter: Scooter?
+    @State private var airPurifier: AirPurifier?
+    @State private var metrics = MetricsService()
 
     @Environment(\.scenePhase) private var scenePhase
 
@@ -220,9 +222,10 @@ struct FluxHausApp: App {
                                 loadCar()
                                 loadScooter()
                                 loadHomeConnect()
+                                loadAirPurifier()
                             }
                         }
-                } else if let hconn, let miele, let robots, let car, let scooter {
+                } else if let hconn, let miele, let robots, let car, let scooter, let airPurifier {
                     ContentView(
                         fluxHausConsts: fluxHausConsts,
                         hconn: hconn,
@@ -231,7 +234,9 @@ struct FluxHausApp: App {
                         battery: battery,
                         car: car,
                         scooter: scooter,
-                        apiResponse: self.apiResponse
+                        apiResponse: self.apiResponse,
+                        airPurifier: airPurifier,
+                        metrics: metrics
                     )
                     .onReceive(NotificationCenter.default.publisher(for: Notification.Name.dataUpdated)) { object in
                         if let response = object.userInfo?["data"] as? LoginResponse {
@@ -242,6 +247,7 @@ struct FluxHausApp: App {
                             miele.setApiResponse(apiResponse: self.apiResponse)
                             car.setApiResponse(apiResponse: self.apiResponse)
                             scooter.setApiResponse(apiResponse: self.apiResponse)
+                            airPurifier.setApiResponse(apiResponse: self.apiResponse)
                             updateLiveActivities(response: response)
                         }
                     }
@@ -266,6 +272,7 @@ struct FluxHausApp: App {
                 robots = nil
                 car = nil
                 scooter = nil
+                airPurifier = nil
             }
             .onChange(of: scenePhase) { _, newPhase in
                 if newPhase == .active {
@@ -345,6 +352,11 @@ struct FluxHausApp: App {
     func loadScooter() {
         scooter = Scooter()
         scooter?.setApiResponse(apiResponse: self.apiResponse)
+    }
+
+    func loadAirPurifier() {
+        airPurifier = AirPurifier()
+        airPurifier?.setApiResponse(apiResponse: self.apiResponse)
     }
 
     func updateLiveActivities(response: LoginResponse) {

--- a/macOS/ContentView.swift
+++ b/macOS/ContentView.swift
@@ -16,6 +16,7 @@ enum SidebarItem: String, CaseIterable, Identifiable {
     case scooter = "Scooter"
     case robots = "Robots"
     case assistant = "Assistant"
+    case metrics = "Metrics"
 
     var id: String { rawValue }
 
@@ -27,7 +28,8 @@ enum SidebarItem: String, CaseIterable, Identifiable {
         case .appliances: return "washer.fill"
         case .car: return "car.fill"
         case .scooter: return "scooter"
-        case .robots: return "fan.fill"
+        case .robots: return "robotic.vacuum.fill"
+        case .metrics: return "chart.xyaxis.line"
         case .assistant: return "bubble.left.and.bubble.right.fill"
         }
     }
@@ -42,6 +44,8 @@ struct ContentView: View {
     var car: Car
     var scooter: Scooter
     var apiResponse: Api
+    var airPurifier: AirPurifier
+    var metrics: MetricsService
     var chat: Chat
     @State private var locationManager = LocationManager()
     @State private var authManager = AuthManager.shared
@@ -65,12 +69,14 @@ struct ContentView: View {
             }
         }
         .toolbar {
-            ToolbarItem(placement: .automatic) {
-                Button(action: {
-                    queryFlux(password: WhereWeAre.getPassword() ?? "")
-                }, label: {
-                    Image(systemName: "arrow.clockwise")
-                })
+            if selectedItem != .metrics {
+                ToolbarItem(placement: .automatic) {
+                    Button(action: {
+                        queryFlux(password: WhereWeAre.getPassword() ?? "")
+                    }, label: {
+                        Image(systemName: "arrow.clockwise")
+                    })
+                }
             }
         }
     }
@@ -106,6 +112,7 @@ struct ContentView: View {
             Button("") { selectedItem = .scooter }.keyboardShortcut("6")
             Button("") { selectedItem = .robots }.keyboardShortcut("7")
             Button("") { selectedItem = .assistant }.keyboardShortcut("8")
+            Button("") { selectedItem = .metrics }.keyboardShortcut("9")
         }
         .frame(width: 0, height: 0)
         .opacity(0)
@@ -124,6 +131,7 @@ struct ContentView: View {
                 car: car,
                 scooter: scooter,
                 apiResponse: apiResponse,
+                airPurifier: airPurifier,
                 locationManager: locationManager,
                 radarService: radarService,
                 onNavigate: { selectedItem = $0 }
@@ -138,7 +146,7 @@ struct ContentView: View {
             SceneView(favouriteScenes: fluxHausConsts.favouriteScenes)
                 .navigationTitle("Scenes")
         case .appliances:
-            AppliancesMacView(hconn: hconn, miele: miele)
+            AppliancesMacView(hconn: hconn, miele: miele, airPurifier: airPurifier)
                 .navigationTitle("Appliances")
         case .car:
             CarDetailView(car: car, locationManager: locationManager)
@@ -149,6 +157,11 @@ struct ContentView: View {
         case .robots:
             RobotsMacView(robots: robots)
                 .navigationTitle("Robots")
+        case .metrics:
+            ScrollView {
+                MetricsView(metrics: metrics)
+            }
+            .navigationTitle("Metrics")
         case .assistant:
             ChatView(chat: chat)
                 .navigationTitle("Assistant")
@@ -160,6 +173,7 @@ struct ContentView: View {
 struct AppliancesMacView: View {
     var hconn: HomeConnect
     var miele: Miele
+    var airPurifier: AirPurifier
 
     private var allAppliances: [(source: String, appliance: Appliance)] {
         hconn.appliances.map { ("HomeConnect", $0) } +
@@ -169,23 +183,16 @@ struct AppliancesMacView: View {
     var body: some View {
         ScrollView {
             VStack(spacing: 16) {
-                if allAppliances.isEmpty {
-                    ContentUnavailableView(
-                        "No Appliances",
-                        systemImage: "washer.fill",
-                        description: Text("All appliances are off")
+                ForEach(
+                    Array(allAppliances.enumerated()),
+                    id: \.offset
+                ) { _, item in
+                    applianceCard(
+                        appliance: item.appliance,
+                        source: item.source
                     )
-                } else {
-                    ForEach(
-                        Array(allAppliances.enumerated()),
-                        id: \.offset
-                    ) { _, item in
-                        applianceCard(
-                            appliance: item.appliance,
-                            source: item.source
-                        )
-                    }
                 }
+                AirPurifierView(purifier: airPurifier)
             }
             .padding()
         }
@@ -286,13 +293,15 @@ struct RobotsMacView: View {
                     title: "BroomBot",
                     robot: robots.broomBot,
                     robotName: "broomBot",
-                    icon: "fan"
+                    icon: "robotic.vacuum.fill",
+                    animation: nil
                 )
                 robotCard(
                     title: "MopBot",
                     robot: robots.mopBot,
                     robotName: "mopBot",
-                    icon: "humidifier.and.droplets"
+                    icon: "humidifier.and.droplets",
+                    animation: .variableColor
                 )
             }
             .padding()
@@ -304,13 +313,15 @@ struct RobotsMacView: View {
         title: String,
         robot: Robot,
         robotName: String,
-        icon: String
+        icon: String,
+        animation: DeviceSymbolAnimation?
     ) -> some View {
         VStack(alignment: .leading, spacing: 12) {
             // Header
             HStack {
                 Image(systemName: icon)
                     .foregroundColor(statusColor(robot))
+                    .deviceSymbolAnimation(animation, isActive: robot.running == true || robot.paused == true)
                 Text(title)
                     .font(Theme.Fonts.headerLarge())
                     .foregroundColor(Theme.Colors.textPrimary)
@@ -454,6 +465,8 @@ struct RobotsMacView: View {
         car: MockData.createCar(),
         scooter: Scooter(),
         apiResponse: MockData.createApi(),
+        airPurifier: MockData.createAirPurifier(),
+        metrics: MetricsService(),
         chat: Chat()
     )
 }

--- a/macOS/DashboardView.swift
+++ b/macOS/DashboardView.swift
@@ -16,6 +16,7 @@ struct DashboardView: View {
     var car: Car
     var scooter: Scooter
     var apiResponse: Api
+    var airPurifier: AirPurifier
     var locationManager: LocationManager
     var radarService: RadarService
     var onNavigate: (SidebarItem) -> Void
@@ -56,23 +57,32 @@ struct DashboardView: View {
         var cards: [DeviceCard] = []
         let broomActive = robots.broomBot.running == true || robots.broomBot.paused == true
         cards.append(DeviceCard(
-            id: "broomBot", isActive: broomActive, priority: broomActive ? 2 : 0,
-            view: AnyView(robotCard(title: "BroomBot", robot: robots.broomBot, robotName: "broomBot", icon: "fan"))
+            id: "broomBot", isActive: broomActive, priority: broomActive ? 3 : 0,
+            view: AnyView(robotCard(
+                title: "BroomBot", robot: robots.broomBot, robotName: "broomBot",
+                icon: "robotic.vacuum.fill", animation: nil
+            ))
         ))
         let mopActive = robots.mopBot.running == true || robots.mopBot.paused == true
         let mopView = robotCard(
-            title: "MopBot", robot: robots.mopBot, robotName: "mopBot", icon: "humidifier.and.droplets"
+            title: "MopBot", robot: robots.mopBot, robotName: "mopBot",
+            icon: "humidifier.and.droplets", animation: .variableColor
         )
-        cards.append(DeviceCard(id: "mopBot", isActive: mopActive, priority: mopActive ? 2 : 0, view: AnyView(mopView)))
+        cards.append(DeviceCard(id: "mopBot", isActive: mopActive, priority: mopActive ? 3 : 0, view: AnyView(mopView)))
         for (idx, item) in allAppliances.enumerated() {
             cards.append(DeviceCard(
                 id: "appliance-\(idx)", isActive: item.appliance.inUse,
-                priority: item.appliance.inUse ? 2 : 0,
+                priority: item.appliance.inUse ? 3 : 0,
                 view: AnyView(applianceCard(appliance: item.appliance, source: item.source))
             ))
         }
-        cards.append(DeviceCard(id: "car", isActive: false, priority: 1, view: AnyView(carCard)))
-        cards.append(DeviceCard(id: "scooter", isActive: false, priority: 1, view: AnyView(scooterCard)))
+        cards.append(DeviceCard(id: "car", isActive: false, priority: 2, view: AnyView(carCard)))
+        cards.append(DeviceCard(id: "scooter", isActive: false, priority: 2, view: AnyView(scooterCard)))
+        let purifierActive = airPurifier.status.online && airPurifier.status.fanOn
+        cards.append(DeviceCard(
+            id: "airPurifier", isActive: purifierActive, priority: purifierActive ? 1 : 0,
+            view: AnyView(AirPurifierView(purifier: airPurifier))
+        ))
         return cards.sorted { $0.priority > $1.priority }
     }
 
@@ -213,10 +223,15 @@ struct DashboardView: View {
     }
 
     // MARK: - Robots
-    private func robotCard(title: String, robot: Robot, robotName: String, icon: String) -> some View {
+    private func robotCard(
+        title: String, robot: Robot, robotName: String, icon: String,
+        animation: DeviceSymbolAnimation?
+    ) -> some View {
         VStack(alignment: .leading, spacing: 12) {
             HStack {
-                Image(systemName: icon).foregroundColor(robotIconColor(robot))
+                Image(systemName: icon)
+                    .foregroundColor(robotIconColor(robot))
+                    .deviceSymbolAnimation(animation, isActive: robot.running == true || robot.paused == true)
                 Text(title).font(Theme.Fonts.headerLarge()).foregroundColor(Theme.Colors.textPrimary)
             }
             VStack(alignment: .leading, spacing: 8) {
@@ -452,6 +467,7 @@ extension DashboardView {
         car: MockData.createCar(),
         scooter: Scooter(),
         apiResponse: MockData.createApi(),
+        airPurifier: MockData.createAirPurifier(),
         locationManager: LocationManager(),
         radarService: RadarService(),
         onNavigate: { _ in }

--- a/macOS/MacApp.swift
+++ b/macOS/MacApp.swift
@@ -389,6 +389,8 @@ struct MacApp: App {
     @State private var car: Car?
     @State private var chat = Chat()
     @State private var scooter: Scooter?
+    @State private var airPurifier: AirPurifier?
+    @State private var metrics = MetricsService()
     @AppStorage("showMenuBarExtra") private var showMenuBar = true
     @Environment(\.openWindow) private var openWindow
 
@@ -414,6 +416,7 @@ struct MacApp: App {
                     self.robots = nil
                     self.car = nil
                     self.scooter = nil
+                    self.airPurifier = nil
                 }
                 .onOpenURL { url in
                     handleDeepLink(url)
@@ -513,7 +516,7 @@ struct MacApp: App {
                 ) { object in
                     handleDataUpdated(object)
                 }
-        } else if let hconn, let miele, let robots, let car, let scooter {
+        } else if let hconn, let miele, let robots, let car, let scooter, let airPurifier {
             ContentView(
                 fluxHausConsts: fluxHausConsts,
                 hconn: hconn,
@@ -523,6 +526,8 @@ struct MacApp: App {
                 car: car,
                 scooter: scooter,
                 apiResponse: apiResponse,
+                airPurifier: airPurifier,
+                metrics: metrics,
                 chat: chat
             )
             .onReceive(
@@ -538,6 +543,7 @@ struct MacApp: App {
                     miele.setApiResponse(apiResponse: self.apiResponse)
                     car.setApiResponse(apiResponse: self.apiResponse)
                     scooter.setApiResponse(apiResponse: self.apiResponse)
+                    airPurifier.setApiResponse(apiResponse: self.apiResponse)
                 }
             }
             .task {
@@ -618,6 +624,8 @@ struct MacApp: App {
             self.car?.setApiResponse(apiResponse: self.apiResponse)
             self.scooter = Scooter()
             self.scooter?.setApiResponse(apiResponse: self.apiResponse)
+            self.airPurifier = AirPurifier()
+            self.airPurifier?.setApiResponse(apiResponse: self.apiResponse)
             self.hconn = HomeConnect(apiResponse: self.apiResponse)
         }
     }

--- a/macOS/MenuBarView.swift
+++ b/macOS/MenuBarView.swift
@@ -100,7 +100,7 @@ struct MenuBarView: View {
                 openAppToSection(.robots)
             }, label: {
                 HStack {
-                    Image(systemName: "fan.fill")
+                    Image(systemName: "robotic.vacuum.fill")
                         .foregroundColor(
                             robots.broomBot.running == true
                                 ? Theme.Colors.accent
@@ -199,7 +199,7 @@ struct MenuBarView: View {
                     }
                 }
                 if robots != nil {
-                    quickButton("Vacuum", icon: "fan") {
+                    quickButton("Vacuum", icon: "robotic.vacuum") {
                         robots?.performAction(
                             action: "start", robot: "broomBot"
                         )


### PR DESCRIPTION
## Summary

Three related pieces of work from this session:

### Metrics dashboard
- Grafana-style charts — one chart per stat, a line per room/series — backed by the server's `/metrics/catalog` and `/metrics/series` endpoints.
- **Dynamic y-axis** scaled to each chart's actual data range (no more temperature stretched across 0–30).
- **Interactive readout**: hover (macOS/visionOS) or touch/drag (iOS) shows a rule line, per-series point markers, and an always-visible value row. The readout lives outside the plot so it is never clipped with many series.
- **Real-time updates**: auto-refreshes every 30s while the view is visible, with an animated (spinning) reload button.
- Group ordering puts **Environment before Car**; the **System** group is hidden.
- **Metrics moved to the end** of navigation on all platforms.

### Air purifier
- The Blue Pure purifier now appears as an appliance on the dashboard and in the appliances list with inline controls, matching robot behaviour.
- Sorted toward the bottom of the active appliances group (after car & scooter).
- Removed the dedicated "Air" tab on all platforms.

### Icons
- MopBot uses a subtle variable-color animation, only while active.
- BroomBot and the Robots navigation item now use the robot-vacuum SF Symbol.

## Testing
- `swiftlint --strict` clean
- iOS, macOS, visionOS builds succeed
- VisionOS unit tests pass (assertion updated for the new Robots icon)

## Notes
- Per-room **humidity** is intentionally single-series: verified against Home Assistant that only the main thermostat (`sensor.home_current_humidity`) reports humidity — ecobee room SmartSensors only measure temperature.
