### PR TITLE
Consistent device icon colors on dashboard

### DIFF
--- a/Shared/AirPurifierView.swift
+++ b/Shared/AirPurifierView.swift
@@ -27,7 +27,11 @@ struct AirPurifierView: View {
         HStack {
             Image(systemName: "air.purifier.fill")
                 .font(Theme.Fonts.headerLarge())
-                .foregroundColor(Theme.Colors.accent)
+                .foregroundColor(
+                    purifier.status.online && purifier.status.fanOn
+                        ? Theme.Colors.accent
+                        : Theme.Colors.textSecondary
+                )
             VStack(alignment: .leading) {
                 Text("Air Purifier")
                     .font(Theme.Fonts.headerLarge())

--- a/Shared/AppliancesViewExtensions.swift
+++ b/Shared/AppliancesViewExtensions.swift
@@ -64,12 +64,8 @@ extension Appliances {
     }
 
     private func getApplianceIconColor(appliances: [Appliance], index: Int) -> Color {
-        if appliances.count > index {
-            if appliances[index].inUse {
-                return Theme.Colors.accent
-            } else if appliances[index].timeRemaining == 0 && appliances[index].programName != "" {
-                return Theme.Colors.success
-            }
+        if appliances.count > index, appliances[index].inUse {
+            return Theme.Colors.accent
         }
         return Theme.Colors.textSecondary
     }


### PR DESCRIPTION
## Summary
Makes device icon colors behave consistently across the dashboard and appliance views.

- **Air purifier**: header icon (`air.purifier.fill`) now shows the accent color only when the purifier is online **and** the fan is on, otherwise neutral — matching how robots and appliances indicate an active state (previously it was always accent).
- **Washer/dryer/appliances**: the icon grid no longer shows a green "finished-but-off" state (`timeRemaining == 0 && programName != ""`). When a machine is not in use the icon returns to neutral, matching the macOS dashboard card and the rest of the devices.

Net effect: a device icon is colored (accent) only while it is actively doing something, and neutral otherwise.