### PR TITLE
feat: outdoor conditions dashboard, consistent outside colour & energy metrics (1.9.1)

### DIFF
--- a/FluxHaus.xcodeproj/project.pbxproj
+++ b/FluxHaus.xcodeproj/project.pbxproj
@@ -1591,7 +1591,7 @@
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.9.0;
+				MARKETING_VERSION = 1.9.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.davidjensenius.FluxHaus.Tests-macOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
@@ -1657,7 +1657,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.9.0;
+				MARKETING_VERSION = 1.9.1;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -1718,7 +1718,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.9.0;
+				MARKETING_VERSION = 1.9.1;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -1746,7 +1746,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.9.0;
+				MARKETING_VERSION = 1.9.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus;
 				PRODUCT_NAME = FluxHaus;
 				SDKROOT = iphoneos;
@@ -1779,7 +1779,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.9.0;
+				MARKETING_VERSION = 1.9.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus;
 				PRODUCT_NAME = FluxHaus;
 				SDKROOT = iphoneos;
@@ -1808,7 +1808,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.9.0;
+				MARKETING_VERSION = 1.9.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.davidjensenius.Tests-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1835,7 +1835,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.9.0;
+				MARKETING_VERSION = 1.9.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.davidjensenius.Tests-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1874,7 +1874,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.9.0;
+				MARKETING_VERSION = 1.9.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus.FluxWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1913,7 +1913,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.9.0;
+				MARKETING_VERSION = 1.9.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus.FluxWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1950,7 +1950,7 @@
 					"@executable_path/Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.9.0;
+				MARKETING_VERSION = 1.9.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus;
 				PRODUCT_MODULE_NAME = FluxHaus;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1988,7 +1988,7 @@
 					"@executable_path/Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.9.0;
+				MARKETING_VERSION = 1.9.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus;
 				PRODUCT_MODULE_NAME = FluxHaus;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2014,7 +2014,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.9.0;
+				MARKETING_VERSION = 1.9.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jensenius.fluxhaus.VisionOSTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = xros;
@@ -2040,7 +2040,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.9.0;
+				MARKETING_VERSION = 1.9.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jensenius.fluxhaus.VisionOSTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = xros;
@@ -2087,7 +2087,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.9.0;
+				MARKETING_VERSION = 1.9.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus;
 				PRODUCT_NAME = FluxHaus;
 				SDKROOT = macosx;
@@ -2127,7 +2127,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.9.0;
+				MARKETING_VERSION = 1.9.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.FluxHaus;
 				PRODUCT_NAME = FluxHaus;
 				SDKROOT = macosx;
@@ -2143,7 +2143,7 @@
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.9.0;
+				MARKETING_VERSION = 1.9.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.davidjensenius.FluxHaus.Tests-macOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;

--- a/Shared/Metrics.swift
+++ b/Shared/Metrics.swift
@@ -96,22 +96,32 @@ public struct MetricSeriesResponse: Codable, Sendable {
     var isRefreshing = false
     var lastError: String?
 
+    /// Groups shown on the main metrics dashboard. "System" is hidden and the
+    /// "Outdoor" group is surfaced on its own detail screen (reachable from the
+    /// Weather tab), so it is excluded here to avoid duplication.
     var groupedCatalog: [(group: String, metrics: [MetricCatalogItem])] {
-        let visible = catalog.filter { $0.group.lowercased() != "system" }
+        let hidden: Set<String> = ["system", "outdoor"]
+        let visible = catalog.filter { !hidden.contains($0.group.lowercased()) }
         let groups = Dictionary(grouping: visible, by: { $0.group })
         return groups.keys.sorted(by: MetricsService.groupSort).map { key in
             (group: key, metrics: groups[key] ?? [])
         }
     }
 
-    /// Preferred group ordering: Environment first, then Car, then the rest
-    /// alphabetically. "System" is filtered out entirely.
+    /// The detailed outdoor/weather metrics surfaced from the Weather tab.
+    var outdoorCatalog: [MetricCatalogItem] {
+        catalog.filter { $0.group.lowercased() == "outdoor" }
+    }
+
+    /// Preferred group ordering: Environment first, then Car, then Energy, then
+    /// the rest alphabetically. "System" is filtered out entirely.
     private static func groupSort(_ lhs: String, _ rhs: String) -> Bool {
         func rank(_ group: String) -> Int {
             switch group.lowercased() {
             case "environment": return 0
             case "car": return 1
-            default: return 2
+            case "energy": return 2
+            default: return 3
             }
         }
         let lRank = rank(lhs), rRank = rank(rhs)

--- a/Shared/MetricsView.swift
+++ b/Shared/MetricsView.swift
@@ -358,9 +358,30 @@ struct EnvironmentMetricsView: View {
         #if os(iOS)
         .navigationBarTitleDisplayMode(.inline)
         #endif
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    Task { await metrics.refresh() }
+                } label: {
+                    Image(systemName: "arrow.clockwise")
+                        .symbolEffect(
+                            .rotate,
+                            options: .repeat(.continuous),
+                            isActive: metrics.isLoading || metrics.isRefreshing
+                        )
+                }
+                .disabled(metrics.isLoading || metrics.isRefreshing)
+            }
+        }
         .task {
             if metrics.catalog.isEmpty {
                 await metrics.refresh()
+            } else if metrics.outdoorCatalog.isEmpty {
+                // The catalog may have been cached before the server exposed the
+                // Outdoor group. Re-fetch it so the new metrics appear without
+                // requiring a manual refresh elsewhere in the app.
+                await metrics.loadCatalog()
+                await metrics.loadAllSeries()
             } else if metrics.series.isEmpty {
                 await metrics.loadAllSeries()
             }

--- a/Shared/MetricsView.swift
+++ b/Shared/MetricsView.swift
@@ -9,6 +9,72 @@
 import SwiftUI
 import Charts
 
+/// Colour assignment for metric chart series.
+///
+/// Any series that represents the outdoors ("Outside") is pinned to a single
+/// fixed colour so it reads consistently across every chart; the remaining
+/// series are drawn from a stable palette in sorted order.
+enum MetricSeriesPalette {
+    /// Fixed colour for outdoor/"Outside" series.
+    static let outside = Theme.Colors.info
+
+    private static let palette: [Color] = [
+        Theme.Colors.success,
+        Theme.Colors.primary,
+        Theme.Colors.accent,
+        Theme.Colors.secondary,
+        Theme.Colors.warning,
+        Theme.Colors.error,
+        .indigo,
+        .pink,
+        .brown,
+        .mint
+    ]
+
+    static func isOutside(_ name: String) -> Bool {
+        let lower = name.lowercased()
+        return lower == "outside"
+            || lower.contains("outdoor")
+            || lower.contains("environment canada")
+            || lower.contains("patio")
+    }
+
+    /// Deterministic name → colour mapping for a set of series names. "Outside"
+    /// series are pinned to `outside`; everything else cycles the palette in
+    /// sorted order so colours stay stable as data updates.
+    static func colorMap(for names: [String]) -> [String: Color] {
+        var map: [String: Color] = [:]
+        var index = 0
+        for name in names.sorted() {
+            if isOutside(name) {
+                map[name] = outside
+            } else {
+                map[name] = palette[index % palette.count]
+                index += 1
+            }
+        }
+        return map
+    }
+}
+
+/// Segmented range picker shared by the metrics dashboards.
+struct MetricRangePicker: View {
+    @Bindable var metrics: MetricsService
+
+    var body: some View {
+        Picker("Range", selection: $metrics.selectedRange) {
+            ForEach(MetricRange.allCases) { range in
+                Text(range.label).tag(range)
+            }
+        }
+        .pickerStyle(.segmented)
+        .padding(.horizontal)
+        .onChange(of: metrics.selectedRange) {
+            Task { await metrics.loadAllSeries() }
+        }
+    }
+}
+
 struct MetricsView: View {
     @Bindable var metrics: MetricsService
 
@@ -57,16 +123,7 @@ struct MetricsView: View {
     }
 
     private var rangePicker: some View {
-        Picker("Range", selection: $metrics.selectedRange) {
-            ForEach(MetricRange.allCases) { range in
-                Text(range.label).tag(range)
-            }
-        }
-        .pickerStyle(.segmented)
-        .padding(.horizontal)
-        .onChange(of: metrics.selectedRange) {
-            Task { await metrics.loadAllSeries() }
-        }
+        MetricRangePicker(metrics: metrics)
     }
 
     @ViewBuilder
@@ -112,6 +169,17 @@ struct MetricChartCard: View {
         (response?.series ?? []).filter { !$0.points.isEmpty }
     }
 
+    /// Series names in the stable (sorted) order used for both the colour scale
+    /// and the legend, so every data source is represented and coloured the same
+    /// way across refreshes.
+    private var sortedNames: [String] {
+        series.map(\.name).sorted()
+    }
+
+    private var colorMap: [String: Color] {
+        MetricSeriesPalette.colorMap(for: sortedNames)
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: Theme.Spacing.small) {
             HStack {
@@ -131,6 +199,9 @@ struct MetricChartCard: View {
             } else {
                 readout
                 chart
+                if series.count > 1 {
+                    legend
+                }
             }
         }
         .padding()
@@ -231,13 +302,89 @@ struct MetricChartCard: View {
                 }
             }
         }
-        .chartLegend(series.count > 1 ? .visible : .hidden)
+        .chartForegroundStyleScale(
+            domain: sortedNames,
+            range: sortedNames.map { colorMap[$0] ?? MetricSeriesPalette.outside }
+        )
+        .chartLegend(.hidden)
         .chartYAxis {
             AxisMarks(position: .leading)
         }
         .chartYScale(domain: yDomain ?? 0...1)
         .chartXSelection(value: $selectedDate)
         .frame(height: 180)
+    }
+
+    /// Wrapping legend so every series (data source) is always visible — a
+    /// horizontal legend clips when there are many rooms/hosts.
+    private var legend: some View {
+        LazyVGrid(
+            columns: [GridItem(.adaptive(minimum: 92), alignment: .leading)],
+            alignment: .leading,
+            spacing: 4
+        ) {
+            ForEach(sortedNames, id: \.self) { name in
+                HStack(spacing: 4) {
+                    Circle()
+                        .fill(colorMap[name] ?? MetricSeriesPalette.outside)
+                        .frame(width: 8, height: 8)
+                    Text(name)
+                        .font(Theme.Fonts.caption)
+                        .foregroundColor(Theme.Colors.textSecondary)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.8)
+                }
+            }
+        }
+    }
+}
+
+/// Detailed outdoor/weather metrics, reachable from the Weather tab. Shows every
+/// metric the server groups under "Outdoor" (temperature, humidity, dew point,
+/// humidex, UV index, AQHI, and U.S./Chinese AQI).
+struct EnvironmentMetricsView: View {
+    @Bindable var metrics: MetricsService
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Theme.Spacing.large) {
+                MetricRangePicker(metrics: metrics)
+                content
+            }
+            .padding(.vertical)
+        }
+        .background(Theme.Colors.background)
+        .navigationTitle("Outdoor Conditions")
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+        .task {
+            if metrics.catalog.isEmpty {
+                await metrics.refresh()
+            } else if metrics.series.isEmpty {
+                await metrics.loadAllSeries()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if metrics.outdoorCatalog.isEmpty {
+            VStack(spacing: Theme.Spacing.small) {
+                Image(systemName: metrics.isLoading ? "arrow.clockwise" : "cloud.sun")
+                    .font(.largeTitle)
+                    .foregroundColor(Theme.Colors.textSecondary)
+                Text(metrics.isLoading ? "Loading…" : (metrics.lastError ?? "No outdoor metrics available"))
+                    .font(Theme.Fonts.bodyMedium)
+                    .foregroundColor(Theme.Colors.textSecondary)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.top, 40)
+        } else {
+            ForEach(metrics.outdoorCatalog) { metric in
+                MetricChartCard(metric: metric, response: metrics.series[metric.id])
+            }
+        }
     }
 }
 

--- a/VisionOS/ContentView.swift
+++ b/VisionOS/ContentView.swift
@@ -108,7 +108,8 @@ struct ContentView: View {
     private var weatherTab: some View {
         WeatherDetailView(
             locationManager: locationManager,
-            radarService: radarService
+            radarService: radarService,
+            metrics: metrics
         )
     }
 

--- a/iOS/ContentView.swift
+++ b/iOS/ContentView.swift
@@ -126,7 +126,8 @@ struct ContentView: View {
     private var weatherTab: some View {
         WeatherDetailView(
             locationManager: locationManager,
-            radarService: radarService
+            radarService: radarService,
+            metrics: metrics
         )
     }
 

--- a/macOS/ContentView.swift
+++ b/macOS/ContentView.swift
@@ -139,7 +139,8 @@ struct ContentView: View {
         case .weather:
             WeatherDetailView(
                 locationManager: locationManager,
-                radarService: radarService
+                radarService: radarService,
+                metrics: metrics
             )
             .navigationTitle("Weather")
         case .scenes:

--- a/macOS/WeatherForecastView.swift
+++ b/macOS/WeatherForecastView.swift
@@ -189,17 +189,20 @@ struct WeatherForecastSection: View {
 struct WeatherDetailView: View {
     var locationManager: LocationManager
     var radarService: RadarService
+    var metrics: MetricsService
     @State private var frameIndex = 0
     @State private var isPlaying = false
     @State private var animationTask: Task<Void, Never>?
     @State private var tilesReady = false
     @State private var showFullRadar = false
+    @State private var showEnvironmentMetrics = false
 
     var body: some View {
         ScrollView {
             VStack(spacing: 16) {
                 if let weather = locationManager.weather {
                     currentWeatherCard(weather: weather)
+                    environmentMetricsCard
                     if let alerts = weather.weatherAlerts, !alerts.isEmpty {
                         weatherAlertsCard(alerts: alerts)
                     }
@@ -219,12 +222,58 @@ struct WeatherDetailView: View {
         #else
         .background(Theme.Colors.background)
         #endif
+        .sheet(isPresented: $showEnvironmentMetrics) {
+            NavigationStack {
+                EnvironmentMetricsView(metrics: metrics)
+                    .toolbar {
+                        ToolbarItem(placement: .cancellationAction) {
+                            Button("Done") { showEnvironmentMetrics = false }
+                        }
+                    }
+            }
+        }
         .task {
             await locationManager.startMonitoring()
             await locationManager.fetchTheWeather()
             await radarService.fetchFrames()
             frameIndex = max(0, radarService.pastFrames.count - 1)
         }
+    }
+
+    /// Entry point to the detailed outdoor metrics dashboard (temperature,
+    /// humidity, dew point, UV index, AQHI, U.S./Chinese AQI, …).
+    private var environmentMetricsCard: some View {
+        Button {
+            showEnvironmentMetrics = true
+        } label: {
+            HStack(spacing: 12) {
+                Image(systemName: "chart.xyaxis.line")
+                    .font(.system(size: 20))
+                    .foregroundColor(Theme.Colors.accent)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Outdoor Conditions")
+                        .font(Theme.Fonts.bodyMedium)
+                        .foregroundColor(Theme.Colors.textPrimary)
+                    Text("Temperature, humidity, UV, air quality & more")
+                        .font(Theme.Fonts.caption)
+                        .foregroundColor(Theme.Colors.textSecondary)
+                        .multilineTextAlignment(.leading)
+                }
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(Theme.Fonts.caption)
+                    .foregroundColor(Theme.Colors.textSecondary)
+            }
+            .padding()
+            #if !os(visionOS)
+            .background(Theme.Colors.secondaryBackground)
+            #endif
+            .cornerRadius(12)
+            #if os(visionOS)
+            .glassBackgroundEffect()
+            #endif
+        }
+        .buttonStyle(.plain)
     }
 
     private func currentWeatherCard(weather: Weather) -> some View {


### PR DESCRIPTION
## Summary

Version **1.9.1**. Surfaces the new outdoor environment + energy data from the [server catalog PR](https://github.com/djensenius/FluxHaus-Server/pull/341) and improves how metric charts read.

### Outdoor data added to existing metrics
The main **Environment** charts (Temperature, Humidity) now include the outdoor Environment Canada reading, and a new **Outdoor Air Quality (AQHI)** chart appears alongside indoor PM2.5 — all driven by the server catalog, so no client wiring per metric.

### New Outdoor Conditions screen (from the Weather tab)
A new card at the top of the Weather tab opens a detailed **Outdoor Conditions** dashboard: outdoor temperature, humidity, dew point, humidex, UV index, AQHI, and U.S./Chinese AQI (IQAir).

### Consistent "Outside" colour
Any series representing the outdoors is pinned to a single fixed colour (`MetricSeriesPalette`) so outdoor readings look the same across every chart. The server relabels these series to **"Outside"**.

### All data sources visible
Replaced the clipped horizontal chart legend with a wrapping grid legend, so every room/host/source stays visible even when there are many series.

### Energy on the main dashboard
The **Energy** group (live power draw in W + cumulative kWh for computer station, media centre, server hardware) now shows on the main metrics dashboard, ranked right after Environment and Car.

## Compatibility
The client reads everything from `GET /metrics/catalog`, so it degrades gracefully until the server PR is shipped — new charts simply appear once the server is deployed.

## Validation
- SwiftLint `--strict`: clean on all changed files.
- Builds succeed for iOS, visionOS, and macOS.
- VisionOS unit tests pass (`** TEST SUCCEEDED **`).